### PR TITLE
feat: improve SEO, add unit tests and enhance URL parser

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   test:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    # Playwright 1.32 predates Ubuntu 24.04 support. Pin Jammy until
+    # Playwright is upgraded to a release that officially supports Noble.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         shard: [1/3, 2/3, 3/3]
@@ -23,7 +25,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(jq -r .dependencies.playwright package.json)" >> "$GITHUB_OUTPUT"
+        run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies[\"@playwright/test\"]' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: pnpm install

--- a/index.html
+++ b/index.html
@@ -8,14 +8,17 @@
     <meta itemprop="name" content="IT Tools - Handy online tools for developers" />
     <meta
       name="description"
-      content="Collection of handy online tools for developers, with great UX. IT Tools is a free and open-source collection of handy online tools for developers & people working in IT."
+      content="Free online developer tools by ePlus.DEV: converters, encoders, generators, network utilities, text tools and more."
     />
     <meta
       itemprop="description"
-      content="Collection of handy online tools for developers, with great UX. IT Tools is a free and open-source collection of handy online tools for developers & people working in IT."
+      content="Free online developer tools by ePlus.DEV: converters, encoders, generators, network utilities, text tools and more."
     />
+    <meta name="author" content="David - ePlus.DEV" />
+    <meta name="application-name" content="IT Tools" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
     <link rel="author" href="humans.txt" />
-    <link rel="canonical" href="https://tools.eplus.dev" />
+    <link rel="canonical" href="https://tools.eplus.dev/" />
 
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
@@ -26,24 +29,47 @@
 
     <meta property="og:url" content="https://tools.eplus.dev/" />
     <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="IT Tools" />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:title" content="IT Tools - Handy online tools for developers" />
     <meta
       property="og:description"
-      content="Collection of handy online tools for developers, with great UX. IT Tools is a free and open-source collection of handy online tools for developers & people working in IT."
+      content="Free online developer tools by ePlus.DEV: converters, encoders, generators, network utilities, text tools and more."
     />
     <meta property="og:image" content="https://tools.eplus.dev/banner.png?v=2" />
+    <meta property="og:image:alt" content="IT Tools - Handy online tools for developers" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@ittoolsdottech" />
-    <meta name="twitter:creator" content="@cthmsst" />
-
+    <meta name="twitter:site" content="@david_nguyen94" />
+    <meta name="twitter:creator" content="@david_nguyen94" />
     <meta name="twitter:title" content="IT Tools - Handy online tools for developers" />
     <meta
       name="twitter:description"
-      content="Collection of handy online tools for developers, with great UX. IT Tools is a free and open-source collection of handy online tools for developers & people working in IT."
+      content="Free online developer tools by ePlus.DEV: converters, encoders, generators, network utilities, text tools and more."
     />
     <meta name="twitter:image" content="https://tools.eplus.dev/banner.png?v=2" />
     <meta name="twitter:image:alt" content="IT Tools - Handy online tools for developers" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "IT Tools",
+        "url": "https://tools.eplus.dev/",
+        "description": "Free online developer tools by ePlus.DEV: converters, encoders, generators, network utilities, text tools and more.",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Any",
+        "isAccessibleForFree": true,
+        "author": {
+          "@type": "Person",
+          "name": "David",
+          "sameAs": [
+            "https://github.com/hoangsvit",
+            "https://twitter.com/david_nguyen94"
+          ]
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/jsdom": "^21.0.0",
     "@types/lodash": "^4.14.192",
-    "@types/mime-types": "^2.1.0",
+    "@types/mime-types": "^2.1.1",
     "@types/netmask": "^2.0.0",
     "@types/node": "^18.15.11",
     "@types/node-forge": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc --noEmit && NODE_OPTIONS=--max_old_space_size=4096 vite build",
+    "build": "node scripts/generate-sitemap.mjs && vue-tsc --noEmit && NODE_OPTIONS=--max_old_space_size=4096 vite build",
     "preview": "vite preview --port 5050",
     "test": "npm run test:unit",
     "test:unit": "vitest --environment jsdom",
@@ -117,7 +117,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/jsdom": "^21.0.0",
     "@types/lodash": "^4.14.192",
-    "@types/mime-types": "^2.1.1",
+    "@types/mime-types": "^2.1.0",
     "@types/netmask": "^2.0.0",
     "@types/node": "^18.15.11",
     "@types/node-forge": "^1.3.2",

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,4 +1,10 @@
-/* TEAM */
+/* SITE */
+Maintainer: David
+GitHub: https://github.com/hoangsvit
+Twitter: @david_nguyen94
+Site: https://tools.eplus.dev
+
+/* ORIGINAL PROJECT */
 Developer: Corentin Thomasset
 Site: https://github.com/CorentinTh
 Twitter: @cthmsst

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
-Disallow:
+Allow: /
+
+Sitemap: https://tools.eplus.dev/sitemap.xml

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,47 @@
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SITE_URL = 'https://tools.eplus.dev';
+const rootDir = fileURLToPath(new URL('..', import.meta.url));
+const toolsDir = join(rootDir, 'src', 'tools');
+const outputPath = join(rootDir, 'public', 'sitemap.xml');
+
+function escapeXml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function collectToolRoutes() {
+  return readdirSync(toolsDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => join(toolsDir, entry.name, 'index.ts'))
+    .flatMap((indexPath) => {
+      try {
+        const source = readFileSync(indexPath, 'utf8');
+        const match = source.match(/\bpath:\s*['"`]([^'"`]+)['"`]/);
+        return match?.[1] ? [match[1]] : [];
+      }
+      catch {
+        return [];
+      }
+    });
+}
+
+const routes = Array.from(new Set(['/', '/about', ...collectToolRoutes()])).sort();
+const urls = routes
+  .map((route) => {
+    const location = new URL(route, `${SITE_URL}/`).toString();
+    const priority = route === '/' ? '1.0' : route === '/about' ? '0.5' : '0.8';
+    return `  <url>\n    <loc>${escapeXml(location)}</loc>\n    <changefreq>monthly</changefreq>\n    <priority>${priority}</priority>\n  </url>`;
+  })
+  .join('\n');
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+
+writeFileSync(outputPath, sitemap, 'utf8');
+console.log(`Generated sitemap with ${routes.length} routes at ${outputPath}`);

--- a/src/layouts/tool.layout.vue
+++ b/src/layouts/tool.layout.vue
@@ -1,33 +1,26 @@
 <script lang="ts" setup>
 import { useRoute } from 'vue-router';
 import { useHead } from '@vueuse/head';
-import type { HeadObject } from '@vueuse/head';
 
 import BaseLayout from './base.layout.vue';
 import FavoriteButton from '@/components/FavoriteButton.vue';
 import type { Tool } from '@/tools/tools.types';
+import { createSeoHead } from '@/utils/seo';
 
 const route = useRoute();
-
-const head = computed<HeadObject>(() => ({
-  title: `${route.meta.name} - IT Tools`,
-  meta: [
-    {
-      name: 'description',
-      content: route.meta?.description as string,
-    },
-    {
-      name: 'keywords',
-      content: ((route.meta.keywords ?? []) as string[]).join(','),
-    },
-  ],
-}));
-useHead(head);
 const { t } = useI18n();
 
 const i18nKey = computed<string>(() => route.path.trim().replace('/', ''));
 const toolTitle = computed<string>(() => t(`tools.${i18nKey.value}.title`, String(route.meta.name)));
 const toolDescription = computed<string>(() => t(`tools.${i18nKey.value}.description`, String(route.meta.description)));
+
+const head = computed(() => createSeoHead({
+  title: toolTitle.value,
+  description: toolDescription.value,
+  path: route.path,
+  keywords: (route.meta.keywords ?? []) as string[],
+}));
+useHead(head);
 </script>
 
 <template>

--- a/src/pages/404.page.vue
+++ b/src/pages/404.page.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
 import { useHead } from '@vueuse/head';
+import { useRoute } from 'vue-router';
+import { createSeoHead } from '@/utils/seo';
 
-useHead({ title: 'Page not found - IT Tools' });
+const route = useRoute();
+useHead(createSeoHead({
+  title: 'Page not found',
+  description: 'The requested IT Tools page could not be found.',
+  path: route.path,
+  noindex: true,
+}));
 </script>
 
 <template>

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { useHead } from '@vueuse/head';
+import { createSeoHead } from '@/utils/seo';
 
-useHead({ title: 'About - IT Tools' });
+useHead(createSeoHead({
+  title: 'About',
+  description: 'About IT Tools by ePlus.DEV, a free and open-source collection of useful online utilities for developers and IT professionals.',
+  path: '/about',
+}));
 </script>
 
 <template>

--- a/src/pages/Home.page.vue
+++ b/src/pages/Home.page.vue
@@ -7,10 +7,11 @@ import ColoredCard from '../components/ColoredCard.vue';
 import ToolCard from '../components/ToolCard.vue';
 import { useToolStore } from '@/tools/tools.store';
 import { config } from '@/config';
+import { createSeoHead } from '@/utils/seo';
 
 const toolStore = useToolStore();
 
-useHead({ title: 'IT Tools - Handy online tools for developers' });
+useHead(createSeoHead());
 const { t } = useI18n();
 
 const favoriteTools = computed(() => toolStore.favoriteTools);

--- a/src/tools/url-parser/index.ts
+++ b/src/tools/url-parser/index.ts
@@ -6,7 +6,7 @@ export const tool = defineTool({
   name: translate('tools.url-parser.title'),
   path: '/url-parser',
   description: translate('tools.url-parser.description'),
-  keywords: ['url', 'parser', 'protocol', 'origin', 'params', 'port', 'username', 'password', 'href'],
+  keywords: ['url', 'parser', 'protocol', 'origin', 'query', 'search params', 'hash', 'port', 'username', 'password', 'href'],
   component: () => import('./url-parser.vue'),
   icon: Unlink,
 });

--- a/src/tools/url-parser/url-parser.service.test.ts
+++ b/src/tools/url-parser/url-parser.service.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { getUrlQueryParams, parseUrl } from './url-parser.service';
+
+describe('url-parser service', () => {
+  it('parses a valid absolute url', () => {
+    const url = parseUrl('https://user:pass@example.com:8080/path?q=hello%20world#section');
+
+    expect(url?.protocol).toBe('https:');
+    expect(url?.username).toBe('user');
+    expect(url?.password).toBe('pass');
+    expect(url?.hostname).toBe('example.com');
+    expect(url?.port).toBe('8080');
+    expect(url?.pathname).toBe('/path');
+    expect(url?.hash).toBe('#section');
+  });
+
+  it('returns undefined for an invalid url', () => {
+    expect(parseUrl('not a url')).toBeUndefined();
+  });
+
+  it('preserves duplicate query parameter keys and decodes their values', () => {
+    const url = parseUrl('https://example.com/?tag=vue&tag=typescript&q=hello%20world');
+
+    expect(getUrlQueryParams(url)).toEqual([
+      { key: 'tag', value: 'vue' },
+      { key: 'tag', value: 'typescript' },
+      { key: 'q', value: 'hello world' },
+    ]);
+  });
+
+  it('returns an empty list when no url is available', () => {
+    expect(getUrlQueryParams()).toEqual([]);
+  });
+});

--- a/src/tools/url-parser/url-parser.service.ts
+++ b/src/tools/url-parser/url-parser.service.ts
@@ -1,0 +1,21 @@
+export interface UrlQueryParam {
+  key: string
+  value: string
+}
+
+export function parseUrl(value: string) {
+  try {
+    return new URL(value);
+  }
+  catch {
+    return undefined;
+  }
+}
+
+export function getUrlQueryParams(url?: URL): UrlQueryParam[] {
+  if (!url) {
+    return [];
+  }
+
+  return Array.from(url.searchParams.entries()).map(([key, value]) => ({ key, value }));
+}

--- a/src/tools/url-parser/url-parser.vue
+++ b/src/tools/url-parser/url-parser.vue
@@ -1,26 +1,28 @@
 <script setup lang="ts">
 import InputCopyable from '../../components/InputCopyable.vue';
-import { isNotThrowing } from '@/utils/boolean';
-import { withDefaultOnError } from '@/utils/defaults';
+import { getUrlQueryParams, parseUrl } from './url-parser.service';
 
 const urlToParse = ref('https://me:pwd@it-tools.tech:3000/url-parser?key1=value&key2=value2#the-hash');
 
-const urlParsed = computed(() => withDefaultOnError(() => new URL(urlToParse.value), undefined));
+const urlParsed = computed(() => parseUrl(urlToParse.value));
+const queryParams = computed(() => getUrlQueryParams(urlParsed.value));
 const urlValidationRules = [
   {
-    validator: (value: string) => isNotThrowing(() => new URL(value)),
+    validator: (value: string) => parseUrl(value) !== undefined,
     message: 'Invalid url',
   },
 ];
 
 const properties: { title: string; key: keyof URL }[] = [
   { title: 'Protocol', key: 'protocol' },
+  { title: 'Origin', key: 'origin' },
   { title: 'Username', key: 'username' },
   { title: 'Password', key: 'password' },
   { title: 'Hostname', key: 'hostname' },
   { title: 'Port', key: 'port' },
   { title: 'Path', key: 'pathname' },
   { title: 'Params', key: 'search' },
+  { title: 'Hash', key: 'hash' },
 ];
 </script>
 
@@ -49,8 +51,8 @@ const properties: { title: string; key: keyof URL }[] = [
     />
 
     <div
-      v-for="[k, v] in Object.entries(Object.fromEntries(urlParsed?.searchParams.entries() ?? []))"
-      :key="k"
+      v-for="({ key, value }, index) in queryParams"
+      :key="`${key}-${value}-${index}`"
       mb-2
       w-full
       flex
@@ -59,8 +61,8 @@ const properties: { title: string; key: keyof URL }[] = [
         <icon-mdi-arrow-right-bottom />
       </div>
 
-      <InputCopyable :value="k" readonly />
-      <InputCopyable :value="v" readonly />
+      <InputCopyable :value="key" readonly />
+      <InputCopyable :value="value" readonly />
     </div>
   </c-card>
 </template>

--- a/src/utils/seo.test.ts
+++ b/src/utils/seo.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { SEO_CONFIG, createSeoHead, getCanonicalUrl, getSeoTitle, normalizeSeoPath } from './seo';
+
+function getMeta(head: ReturnType<typeof createSeoHead>, key: string) {
+  const meta = (head.meta ?? []) as Array<{ name?: string; property?: string; content?: string }>;
+  return meta.find(item => item.name === key || item.property === key)?.content;
+}
+
+describe('seo helpers', () => {
+  it('normalizes route paths before creating canonical urls', () => {
+    expect(normalizeSeoPath('/url-parser/?foo=bar#hash')).toBe('/url-parser');
+    expect(normalizeSeoPath('url-parser/')).toBe('/url-parser');
+    expect(normalizeSeoPath('/')).toBe('/');
+    expect(getCanonicalUrl('/url-parser?foo=bar')).toBe('https://tools.eplus.dev/url-parser');
+  });
+
+  it('adds the site name to page titles only once', () => {
+    expect(getSeoTitle('URL Parser')).toBe('URL Parser - IT Tools');
+    expect(getSeoTitle('About - IT Tools')).toBe('About - IT Tools');
+    expect(getSeoTitle()).toBe(SEO_CONFIG.defaultTitle);
+  });
+
+  it('creates canonical, Open Graph and Twitter metadata for a tool route', () => {
+    const head = createSeoHead({
+      title: 'URL Parser',
+      description: 'Parse URLs and inspect their components.',
+      path: '/url-parser?utm_source=test',
+      keywords: ['url', 'parser'],
+    });
+
+    expect(head.title).toBe('URL Parser - IT Tools');
+    expect(head.link).toContainEqual({ rel: 'canonical', href: 'https://tools.eplus.dev/url-parser' });
+    expect(getMeta(head, 'description')).toBe('Parse URLs and inspect their components.');
+    expect(getMeta(head, 'keywords')).toBe('url, parser');
+    expect(getMeta(head, 'og:url')).toBe('https://tools.eplus.dev/url-parser');
+    expect(getMeta(head, 'og:title')).toBe('URL Parser - IT Tools');
+    expect(getMeta(head, 'twitter:creator')).toBe('@david_nguyen94');
+  });
+
+  it('marks non-indexable pages with noindex and nofollow', () => {
+    const head = createSeoHead({ title: 'Not found', path: '/missing', noindex: true });
+
+    expect(getMeta(head, 'robots')).toBe('noindex, nofollow');
+  });
+});

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,82 @@
+import type { HeadObject } from '@vueuse/head';
+
+export const SEO_CONFIG = {
+  siteName: 'IT Tools',
+  siteUrl: 'https://tools.eplus.dev',
+  defaultTitle: 'IT Tools - Handy online tools for developers',
+  defaultDescription:
+    'Free online developer tools by ePlus.DEV: converters, encoders, generators, network utilities, text tools and more.',
+  socialImage: 'https://tools.eplus.dev/banner.png?v=2',
+  twitterHandle: '@david_nguyen94',
+} as const;
+
+interface SeoHeadOptions {
+  title?: string
+  description?: string
+  path?: string
+  keywords?: string[]
+  noindex?: boolean
+  type?: 'website' | 'article'
+}
+
+export function normalizeSeoPath(path = '/') {
+  const withoutQueryOrHash = path.split(/[?#]/, 1)[0] || '/';
+  const withLeadingSlash = withoutQueryOrHash.startsWith('/') ? withoutQueryOrHash : `/${withoutQueryOrHash}`;
+
+  if (withLeadingSlash === '/') {
+    return '/';
+  }
+
+  return withLeadingSlash.replace(/\/+$/, '');
+}
+
+export function getCanonicalUrl(path = '/') {
+  return new URL(normalizeSeoPath(path), `${SEO_CONFIG.siteUrl}/`).toString();
+}
+
+export function getSeoTitle(title?: string) {
+  if (!title) {
+    return SEO_CONFIG.defaultTitle;
+  }
+
+  return title.includes(SEO_CONFIG.siteName) ? title : `${title} - ${SEO_CONFIG.siteName}`;
+}
+
+export function createSeoHead({
+  title,
+  description = SEO_CONFIG.defaultDescription,
+  path = '/',
+  keywords = [],
+  noindex = false,
+  type = 'website',
+}: SeoHeadOptions = {}): HeadObject {
+  const resolvedTitle = getSeoTitle(title);
+  const canonicalUrl = getCanonicalUrl(path);
+  const robots = noindex
+    ? 'noindex, nofollow'
+    : 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1';
+
+  return {
+    title: resolvedTitle,
+    link: [
+      { rel: 'canonical', href: canonicalUrl },
+    ],
+    meta: [
+      { name: 'description', content: description },
+      ...(keywords.length > 0 ? [{ name: 'keywords', content: keywords.join(', ') }] : []),
+      { name: 'robots', content: robots },
+      { property: 'og:type', content: type },
+      { property: 'og:site_name', content: SEO_CONFIG.siteName },
+      { property: 'og:url', content: canonicalUrl },
+      { property: 'og:title', content: resolvedTitle },
+      { property: 'og:description', content: description },
+      { property: 'og:image', content: SEO_CONFIG.socialImage },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'twitter:site', content: SEO_CONFIG.twitterHandle },
+      { name: 'twitter:creator', content: SEO_CONFIG.twitterHandle },
+      { name: 'twitter:title', content: resolvedTitle },
+      { name: 'twitter:description', content: description },
+      { name: 'twitter:image', content: SEO_CONFIG.socialImage },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

- add reusable route-level SEO metadata with canonical URLs, Open Graph and Twitter cards
- improve static metadata and maintainer ownership signals for tools.eplus.dev
- mark 404 pages as noindex/nofollow
- generate sitemap.xml automatically from registered tool routes during build and expose it in robots.txt
- enhance URL Parser with origin/hash fields and preserve duplicate query parameters
- add unit tests for SEO helpers and URL parsing behavior

## Test coverage added

- canonical URL normalization
- title de-duplication
- Open Graph/Twitter metadata generation
- noindex metadata
- valid/invalid URL parsing
- hash/credentials parsing
- duplicate query parameter preservation and URL decoding

## Notes

The original upstream author attribution remains in `public/humans.txt`; this change only adds maintainer/ownership metadata for this fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic sitemap generation for tool, home, and About pages.
  * Improved URL parsing with query-parameter and hash extraction, validation, duplicate-key handling, and decoded values.
* **Improvements**
  * Standardized page metadata, canonical URLs, social previews, indexing directives, and structured data across the site.
  * Enhanced URL parser search keywords for better discoverability.
  * Updated crawler guidance to include the sitemap and allow indexing.
* **Tests**
  * Expanded coverage for URL parsing and SEO metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->