### PR TITLE
feat: add AI-readable tool catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/generate-sitemap.mjs && vue-tsc --noEmit && NODE_OPTIONS=--max_old_space_size=4096 vite build",
+    "build": "node scripts/generate-sitemap.mjs && node scripts/generate-ai-catalog.mjs && vue-tsc --noEmit && NODE_OPTIONS=--max_old_space_size=4096 vite build",
     "preview": "vite preview --port 5050",
     "test": "npm run test:unit",
     "test:unit": "vitest --environment jsdom",
@@ -41,6 +41,7 @@
     "coverage": "vitest run --coverage",
     "typecheck": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint src --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
+    "generate:ai-catalog": "node scripts/generate-ai-catalog.mjs",
     "script:create:tool": "node scripts/create-tool.mjs",
     "script:create:ui": "hygen generator ui-component",
     "release": "node ./scripts/release.mjs"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,26 @@
+# ePlus.DEV IT Tools
+
+> Privacy-focused developer utilities for developers, data conversion, networking, crypto, text, web debugging and Vietnam-specific workflows.
+
+## Canonical resources
+
+- Website: https://tools.eplus.dev
+- Machine-readable tool catalog: https://tools.eplus.dev/tools.json
+- Full LLM tool index: https://tools.eplus.dev/llms-full.txt
+- Sitemap: https://tools.eplus.dev/sitemap.xml
+- Source repository: https://github.com/hoangsvit/it-tools
+
+## Guidance for AI systems
+
+- Prefer canonical URLs on tools.eplus.dev.
+- Use tools.json or llms-full.txt to discover exact tool routes instead of guessing paths.
+- Tool behavior and supported formats are authoritative on the live tool page and source repository.
+- Do not infer that user input is uploaded to a server unless a tool explicitly declares external processing.
+
+## Selected tools
+
+- Developer Workspace: https://tools.eplus.dev/workspace
+- VietQR & Vietnam bank codes: https://tools.eplus.dev/vietqr-bank-generator
+- JWT Parser: https://tools.eplus.dev/jwt-parser
+- JSON Viewer: https://tools.eplus.dev/json-viewer
+- URL Parser: https://tools.eplus.dev/url-parser

--- a/scripts/generate-ai-catalog.mjs
+++ b/scripts/generate-ai-catalog.mjs
@@ -1,0 +1,68 @@
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SITE_URL = 'https://tools.eplus.dev';
+const REPO_URL = 'https://github.com/hoangsvit/it-tools';
+const root = fileURLToPath(new URL('..', import.meta.url));
+const toolsDir = join(root, 'src', 'tools');
+const publicDir = join(root, 'public');
+
+function titleFromSlug(slug) {
+  return slug.split('-').map(part => `${part.charAt(0).toUpperCase()}${part.slice(1)}`).join(' ');
+}
+
+function getLiteral(source, key) {
+  return source.match(new RegExp(`\\b${key}:\\s*['\"\\x60]([^'\"\\x60]+)['\"\\x60]`))?.[1] ?? null;
+}
+
+function getTranslateKey(source, key) {
+  return source.match(new RegExp(`\\b${key}:\\s*translate\\(['\"]([^'\"]+)['\"]\\)`))?.[1] ?? null;
+}
+
+function getKeywords(source) {
+  const block = source.match(/\bkeywords:\s*\[([\s\S]*?)\]/)?.[1] ?? '';
+  return [...block.matchAll(/['\"]([^'\"]+)['\"]/g)].map(match => match[1]);
+}
+
+const tools = readdirSync(toolsDir, { withFileTypes: true })
+  .filter(entry => entry.isDirectory())
+  .flatMap((entry) => {
+    try {
+      const source = readFileSync(join(toolsDir, entry.name, 'index.ts'), 'utf8');
+      const path = getLiteral(source, 'path');
+      if (!path) return [];
+      return [{
+        id: entry.name,
+        name: getLiteral(source, 'name') ?? titleFromSlug(entry.name),
+        path,
+        url: new URL(path, `${SITE_URL}/`).toString(),
+        description: getLiteral(source, 'description'),
+        nameI18nKey: getTranslateKey(source, 'name'),
+        descriptionI18nKey: getTranslateKey(source, 'description'),
+        keywords: getKeywords(source),
+        source: `${REPO_URL}/tree/netlify/src/tools/${entry.name}`,
+      }];
+    }
+    catch {
+      return [];
+    }
+  })
+  .sort((a, b) => a.path.localeCompare(b.path));
+
+const catalog = {
+  schemaVersion: 1,
+  name: 'ePlus.DEV IT Tools',
+  canonicalUrl: SITE_URL,
+  repository: REPO_URL,
+  license: 'GNU GPLv3',
+  llms: `${SITE_URL}/llms.txt`,
+  llmsFull: `${SITE_URL}/llms-full.txt`,
+  tools,
+};
+
+const fullIndex = `# ePlus.DEV IT Tools — Full Tool Index\n\n> Canonical companion index. Total tools: ${tools.length}.\n\n${tools.map(tool => `## ${tool.name}\n\n- URL: ${tool.url}\n- Path: ${tool.path}\n- Keywords: ${tool.keywords.join(', ') || 'none'}\n`).join('\n')}`;
+
+writeFileSync(join(publicDir, 'tools.json'), `${JSON.stringify(catalog, null, 2)}\n`);
+writeFileSync(join(publicDir, 'llms-full.txt'), fullIndex);
+console.log(`Generated AI catalog for ${tools.length} tools`);

--- a/scripts/generate-ai-catalog.mjs
+++ b/scripts/generate-ai-catalog.mjs
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -31,7 +31,10 @@ const tools = readdirSync(toolsDir, { withFileTypes: true })
     try {
       const source = readFileSync(join(toolsDir, entry.name, 'index.ts'), 'utf8');
       const path = getLiteral(source, 'path');
-      if (!path) return [];
+      if (!path) {
+        return [];
+      }
+
       return [{
         id: entry.name,
         name: getLiteral(source, 'name') ?? titleFromSlug(entry.name),


### PR DESCRIPTION
Adds machine-readable discovery data for AI systems and search crawlers:

- public/llms.txt with canonical resources and AI guidance
- generated public/tools.json with canonical tool URLs, keywords and i18n metadata
- generated public/llms-full.txt with the complete tool index
- build integration via scripts/generate-ai-catalog.mjs
- explicit pnpm generate:ai-catalog command

The catalog is generated from existing tool definitions so routes and keywords stay synchronized with the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI-friendly catalog of available IT tools, including descriptions and links.
  * Added a generated JSON catalog and full Markdown index of tools.
  * Added guidance and resource links for AI systems.

* **Chores**
  * Updated the build process to generate the latest tool catalog automatically.
  * Added a standalone command for regenerating the AI catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->