### PR TITLE
feat: add browser-local GZip and hexdump tools

### DIFF
--- a/src/tools/gzip-compressor/gzip-compressor.service.ts
+++ b/src/tools/gzip-compressor/gzip-compressor.service.ts
@@ -1,0 +1,50 @@
+function bytesToBase64(bytes: Uint8Array) {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string) {
+  const compact = value.replace(/\s+/g, '');
+  const binary = atob(compact);
+  return Uint8Array.from(binary, character => character.charCodeAt(0));
+}
+
+async function streamToUint8Array(stream: ReadableStream<Uint8Array>) {
+  const buffer = await new Response(stream).arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+export function supportsGzipStreams() {
+  return typeof CompressionStream !== 'undefined' && typeof DecompressionStream !== 'undefined';
+}
+
+export async function gzipTextToBase64(value: string) {
+  if (!supportsGzipStreams()) {
+    throw new Error('Compression Streams API is not supported by this browser.');
+  }
+
+  const input = new Blob([new TextEncoder().encode(value)]).stream();
+  const compressed = input.pipeThrough(new CompressionStream('gzip'));
+  return bytesToBase64(await streamToUint8Array(compressed));
+}
+
+export async function gunzipBase64ToText(value: string) {
+  if (!supportsGzipStreams()) {
+    throw new Error('Compression Streams API is not supported by this browser.');
+  }
+
+  const bytes = base64ToBytes(value);
+  const input = new Blob([bytes]).stream();
+  const decompressed = input.pipeThrough(new DecompressionStream('gzip'));
+  const output = await streamToUint8Array(decompressed);
+  return new TextDecoder().decode(output);
+}
+
+export function isLikelyGzipBase64(value: string) {
+  const compact = value.replace(/\s+/g, '');
+  return compact.startsWith('H4sI') && /^[A-Za-z0-9+/]+=*$/.test(compact);
+}

--- a/src/tools/gzip-compressor/gzip-compressor.vue
+++ b/src/tools/gzip-compressor/gzip-compressor.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { useCopy } from '@/composable/copy';
+import {
+  gunzipBase64ToText,
+  gzipTextToBase64,
+  isLikelyGzipBase64,
+  supportsGzipStreams,
+} from './gzip-compressor.service';
+
+const textInput = ref('');
+const gzipOutput = ref('');
+const gzipInput = ref('');
+const textOutput = ref('');
+const compressing = ref(false);
+const decompressing = ref(false);
+const compressError = ref('');
+const decompressError = ref('');
+const supported = supportsGzipStreams();
+
+const { copy: copyCompressed } = useCopy({ source: gzipOutput, text: 'Compressed GZip Base64 copied to the clipboard' });
+const { copy: copyDecompressed } = useCopy({ source: textOutput, text: 'Decompressed text copied to the clipboard' });
+
+async function compress() {
+  compressError.value = '';
+  gzipOutput.value = '';
+  if (!textInput.value) {
+    return;
+  }
+
+  compressing.value = true;
+  try {
+    gzipOutput.value = await gzipTextToBase64(textInput.value);
+  }
+  catch (error) {
+    compressError.value = error instanceof Error ? error.message : 'Unable to compress this text.';
+  }
+  finally {
+    compressing.value = false;
+  }
+}
+
+async function decompress() {
+  decompressError.value = '';
+  textOutput.value = '';
+  if (!gzipInput.value.trim()) {
+    return;
+  }
+
+  decompressing.value = true;
+  try {
+    textOutput.value = await gunzipBase64ToText(gzipInput.value.trim());
+  }
+  catch {
+    decompressError.value = 'Invalid or unsupported GZip Base64 payload.';
+  }
+  finally {
+    decompressing.value = false;
+  }
+}
+</script>
+
+<template>
+  <n-alert v-if="!supported" type="warning" :bordered="false" mb-4>
+    This browser does not expose the Compression Streams API required by this tool.
+  </n-alert>
+
+  <c-card title="Text to GZip Base64">
+    <c-input-text
+      v-model:value="textInput"
+      multiline
+      raw-text
+      rows="7"
+      label="Text to compress"
+      placeholder="Paste JSON, logs, XML or any UTF-8 text..."
+      mb-4
+    />
+
+    <div flex justify-center mb-4>
+      <c-button :disabled="!supported || !textInput" :loading="compressing" @click="compress">
+        Compress with GZip
+      </c-button>
+    </div>
+
+    <n-alert v-if="compressError" type="error" :bordered="false" mb-4>
+      {{ compressError }}
+    </n-alert>
+
+    <c-input-text
+      :value="gzipOutput"
+      multiline
+      readonly
+      rows="7"
+      label="GZip payload (Base64)"
+      placeholder="Compressed Base64 output will appear here"
+      mb-4
+    />
+
+    <div flex justify-center>
+      <c-button :disabled="!gzipOutput" @click="copyCompressed()">
+        Copy compressed payload
+      </c-button>
+    </div>
+  </c-card>
+
+  <c-card title="GZip Base64 to text">
+    <c-input-text
+      v-model:value="gzipInput"
+      multiline
+      raw-text
+      rows="7"
+      label="GZip Base64 payload"
+      placeholder="Usually starts with H4sI..."
+      mb-2
+    />
+
+    <n-alert v-if="gzipInput.trim() && !isLikelyGzipBase64(gzipInput)" type="warning" :bordered="false" mb-4>
+      This value does not look like a standard GZip Base64 payload, but you can still try to decompress it.
+    </n-alert>
+
+    <div flex justify-center mb-4>
+      <c-button :disabled="!supported || !gzipInput.trim()" :loading="decompressing" @click="decompress">
+        Decompress GZip
+      </c-button>
+    </div>
+
+    <n-alert v-if="decompressError" type="error" :bordered="false" mb-4>
+      {{ decompressError }}
+    </n-alert>
+
+    <c-input-text
+      :value="textOutput"
+      multiline
+      readonly
+      rows="7"
+      label="Decompressed text"
+      placeholder="Decompressed UTF-8 text will appear here"
+      mb-4
+    />
+
+    <div flex justify-center>
+      <c-button :disabled="!textOutput" @click="copyDecompressed()">
+        Copy decompressed text
+      </c-button>
+    </div>
+  </c-card>
+</template>

--- a/src/tools/gzip-compressor/gzip-compressor.vue
+++ b/src/tools/gzip-compressor/gzip-compressor.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { useCopy } from '@/composable/copy';
 import {
   gunzipBase64ToText,
   gzipTextToBase64,
   isLikelyGzipBase64,
   supportsGzipStreams,
 } from './gzip-compressor.service';
+import { useCopy } from '@/composable/copy';
 
 const textInput = ref('');
 const gzipOutput = ref('');

--- a/src/tools/gzip-compressor/index.ts
+++ b/src/tools/gzip-compressor/index.ts
@@ -13,5 +13,5 @@ export const tool = defineTool({
     mode: 'local',
     summary: 'Compression and decompression run locally in your browser using the Compression Streams API.',
   },
-  capabilities: ['text-input', 'clipboard', 'offline', 'file-export'],
+  capabilities: ['text-input', 'clipboard', 'offline'],
 });

--- a/src/tools/gzip-compressor/index.ts
+++ b/src/tools/gzip-compressor/index.ts
@@ -1,4 +1,4 @@
-import { FileZip } from '@vicons/tabler';
+import { File } from '@vicons/tabler';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
@@ -7,7 +7,7 @@ export const tool = defineTool({
   description: 'Compress text to GZip or decompress Base64-encoded GZip data entirely in your browser.',
   keywords: ['gzip', 'compress', 'decompress', 'deflate', 'base64', 'archive', 'browser', 'local'],
   component: () => import('./gzip-compressor.vue'),
-  icon: FileZip,
+  icon: File,
   createdAt: new Date('2026-08-09'),
   privacy: {
     mode: 'local',

--- a/src/tools/gzip-compressor/index.ts
+++ b/src/tools/gzip-compressor/index.ts
@@ -1,0 +1,17 @@
+import { FileZip } from '@vicons/tabler';
+import { defineTool } from '../tool';
+
+export const tool = defineTool({
+  name: 'GZip compressor & decompressor',
+  path: '/gzip-compressor',
+  description: 'Compress text to GZip or decompress Base64-encoded GZip data entirely in your browser.',
+  keywords: ['gzip', 'compress', 'decompress', 'deflate', 'base64', 'archive', 'browser', 'local'],
+  component: () => import('./gzip-compressor.vue'),
+  icon: FileZip,
+  createdAt: new Date('2026-08-09'),
+  privacy: {
+    mode: 'local',
+    summary: 'Compression and decompression run locally in your browser using the Compression Streams API.',
+  },
+  capabilities: ['text-input', 'clipboard', 'offline', 'file-export'],
+});

--- a/src/tools/hexdump-inspector/hexdump-inspector.service.test.ts
+++ b/src/tools/hexdump-inspector/hexdump-inspector.service.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { hexToText, isValidHexInput, normalizeHexInput, textToHexdump } from './hexdump-inspector.service';
+
+describe('hexdump inspector', () => {
+  it('renders offsets, bytes and ASCII preview', () => {
+    expect(textToHexdump('Hello')).toBe('00000000  48 65 6c 6c 6f                                   |Hello|');
+  });
+
+  it('normalizes common hex input formats', () => {
+    expect(normalizeHexInput('0x48 0x65 6c:6c:6f')).toBe('48656c6c6f');
+    expect(isValidHexInput('48 65 6c 6c 6f')).toBe(true);
+    expect(isValidHexInput('4')).toBe(false);
+  });
+
+  it('decodes UTF-8 byte sequences', () => {
+    expect(hexToText('48 65 6c 6c 6f')).toBe('Hello');
+    expect(hexToText('56 69 e1 bb 87 74 20 4e 61 6d')).toBe('Việt Nam');
+  });
+});

--- a/src/tools/hexdump-inspector/hexdump-inspector.service.ts
+++ b/src/tools/hexdump-inspector/hexdump-inspector.service.ts
@@ -1,0 +1,44 @@
+export function textToHexdump(value: string, bytesPerRow = 16) {
+  const bytes = new TextEncoder().encode(value);
+  const rows: string[] = [];
+
+  for (let offset = 0; offset < bytes.length; offset += bytesPerRow) {
+    const row = bytes.slice(offset, offset + bytesPerRow);
+    const hex = [...row]
+      .map(byte => byte.toString(16).padStart(2, '0'))
+      .join(' ')
+      .padEnd(bytesPerRow * 3 - 1, ' ');
+    const ascii = [...row]
+      .map(byte => byte >= 32 && byte <= 126 ? String.fromCharCode(byte) : '.')
+      .join('');
+
+    rows.push(`${offset.toString(16).padStart(8, '0')}  ${hex}  |${ascii}|`);
+  }
+
+  return rows.join('\n');
+}
+
+export function normalizeHexInput(value: string) {
+  return value
+    .replace(/0x/gi, '')
+    .replace(/[^0-9a-f]/gi, '');
+}
+
+export function isValidHexInput(value: string) {
+  const normalized = normalizeHexInput(value);
+  return normalized.length > 0 && normalized.length % 2 === 0;
+}
+
+export function hexToText(value: string) {
+  const normalized = normalizeHexInput(value);
+  if (!normalized || normalized.length % 2 !== 0) {
+    throw new Error('Hex input must contain complete bytes.');
+  }
+
+  const bytes = new Uint8Array(normalized.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(normalized.slice(index * 2, index * 2 + 2), 16);
+  }
+
+  return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+}

--- a/src/tools/hexdump-inspector/hexdump-inspector.vue
+++ b/src/tools/hexdump-inspector/hexdump-inspector.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { useCopy } from '@/composable/copy';
+import { hexToText, isValidHexInput, textToHexdump } from './hexdump-inspector.service';
+
+const textInput = ref('Hello, ePlus.DEV!');
+const hexInput = ref('48 65 6c 6c 6f');
+const decodeError = ref('');
+
+const hexdump = computed(() => textToHexdump(textInput.value));
+const decodedText = computed(() => {
+  decodeError.value = '';
+  if (!hexInput.value.trim()) {
+    return '';
+  }
+
+  try {
+    return hexToText(hexInput.value);
+  }
+  catch (error) {
+    decodeError.value = error instanceof Error ? error.message : 'Invalid hex input.';
+    return '';
+  }
+});
+
+const { copy: copyHexdump } = useCopy({ source: hexdump, text: 'Hexdump copied to the clipboard' });
+const { copy: copyDecodedText } = useCopy({ source: decodedText, text: 'Decoded text copied to the clipboard' });
+</script>
+
+<template>
+  <c-card title="Text to hexdump">
+    <c-input-text
+      v-model:value="textInput"
+      multiline
+      raw-text
+      rows="6"
+      label="UTF-8 text"
+      placeholder="Paste text to inspect its bytes..."
+      mb-4
+    />
+
+    <c-input-text
+      :value="hexdump"
+      multiline
+      readonly
+      rows="10"
+      label="Hexdump"
+      placeholder="Byte offsets, hex values and ASCII preview will appear here"
+      mb-4
+    />
+
+    <div flex justify-center>
+      <c-button :disabled="!hexdump" @click="copyHexdump()">
+        Copy hexdump
+      </c-button>
+    </div>
+  </c-card>
+
+  <c-card title="Hex bytes to UTF-8 text">
+    <c-input-text
+      v-model:value="hexInput"
+      multiline
+      raw-text
+      rows="6"
+      label="Hex bytes"
+      placeholder="48 65 6c 6c 6f or 0x48 0x65..."
+      mb-3
+    />
+
+    <n-alert v-if="hexInput.trim() && !isValidHexInput(hexInput)" type="warning" :bordered="false" mb-4>
+      Hex input must contain complete byte pairs.
+    </n-alert>
+
+    <n-alert v-if="decodeError" type="error" :bordered="false" mb-4>
+      {{ decodeError }}
+    </n-alert>
+
+    <c-input-text
+      :value="decodedText"
+      multiline
+      readonly
+      rows="6"
+      label="Decoded UTF-8 text"
+      placeholder="Decoded text will appear here"
+      mb-4
+    />
+
+    <div flex justify-center>
+      <c-button :disabled="!decodedText" @click="copyDecodedText()">
+        Copy decoded text
+      </c-button>
+    </div>
+  </c-card>
+</template>

--- a/src/tools/hexdump-inspector/hexdump-inspector.vue
+++ b/src/tools/hexdump-inspector/hexdump-inspector.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useCopy } from '@/composable/copy';
 import { hexToText, isValidHexInput, textToHexdump } from './hexdump-inspector.service';
+import { useCopy } from '@/composable/copy';
 
 const textInput = ref('Hello, ePlus.DEV!');
 const hexInput = ref('48 65 6c 6c 6f');

--- a/src/tools/hexdump-inspector/index.ts
+++ b/src/tools/hexdump-inspector/index.ts
@@ -1,4 +1,4 @@
-import { FileCode } from '@vicons/tabler';
+import { File } from '@vicons/tabler';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
@@ -7,7 +7,7 @@ export const tool = defineTool({
   description: 'Turn text into a classic hex dump and decode hex bytes back into UTF-8 text in your browser.',
   keywords: ['hex', 'hexdump', 'bytes', 'binary', 'utf8', 'ascii', 'decode', 'encode', 'inspector'],
   component: () => import('./hexdump-inspector.vue'),
-  icon: FileCode,
+  icon: File,
   createdAt: new Date('2026-08-09'),
   privacy: {
     mode: 'local',

--- a/src/tools/hexdump-inspector/index.ts
+++ b/src/tools/hexdump-inspector/index.ts
@@ -1,0 +1,17 @@
+import { FileCode } from '@vicons/tabler';
+import { defineTool } from '../tool';
+
+export const tool = defineTool({
+  name: 'Hexdump inspector',
+  path: '/hexdump-inspector',
+  description: 'Turn text into a classic hex dump and decode hex bytes back into UTF-8 text in your browser.',
+  keywords: ['hex', 'hexdump', 'bytes', 'binary', 'utf8', 'ascii', 'decode', 'encode', 'inspector'],
+  component: () => import('./hexdump-inspector.vue'),
+  icon: FileCode,
+  createdAt: new Date('2026-08-09'),
+  privacy: {
+    mode: 'local',
+    summary: 'Text and byte conversion is performed locally in your browser.',
+  },
+  capabilities: ['text-input', 'clipboard', 'offline'],
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,8 @@ import { tool as base64StringConverter } from './base64-string-converter';
 import { tool as basicAuthGenerator } from './basic-auth-generator';
 import { tool as emailNormalizer } from './email-normalizer';
 import { tool as fileInspector } from './file-inspector';
+import { tool as gzipCompressor } from './gzip-compressor';
+import { tool as hexdumpInspector } from './hexdump-inspector';
 import { tool as asciiTextDrawer } from './ascii-text-drawer';
 import { tool as textToUnicode } from './text-to-unicode';
 import { tool as safelinkDecoder } from './safelink-decoder';
@@ -105,6 +107,7 @@ const coreCategories: ToolCategory[] = [
       romanNumeralConverter,
       base64StringConverter,
       base64FileConverter,
+      gzipCompressor,
       colorConverter,
       caseConverter,
       textToNatoAlphabet,
@@ -165,6 +168,7 @@ const coreCategories: ToolCategory[] = [
       regexTester,
       regexMemo,
       fileInspector,
+      hexdumpInspector,
     ],
   },
   {


### PR DESCRIPTION
Adds two new privacy-first developer utilities inspired by common DevToys/CyberChef workflows:

- GZip compressor & decompressor
  - UTF-8 text -> GZip -> Base64
  - Base64 GZip -> UTF-8 text
  - browser-local Compression Streams API
  - capability detection and invalid payload handling
- Hexdump inspector
  - classic offset + hex + ASCII dump
  - decode common hex byte formats back to UTF-8
  - regression tests including Vietnamese UTF-8 text

Both tools are registered in the existing tool catalog so sitemap and AI-readable catalogs pick them up automatically during build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GZip tool for compressing text to Base64 and decompressing GZip-Base64 data.
  * Added browser support checks, validation, error feedback, and clipboard copy actions.
  * Added a Hexdump Inspector for converting text to hexdumps and hexadecimal data to UTF-8 text.
  * Added validation, formatting, error feedback, and clipboard copy actions for hexdump conversions.
  * Registered both tools in the appropriate tool categories.

* **Tests**
  * Added coverage for hexdump formatting, validation, normalization, and UTF-8 decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->