### PR TITLE
feat: add Schema and SEO audit tools

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -78,6 +78,8 @@ import { tool as qrCodeGenerator } from './qr-code-generator';
 import { tool as wifiQrCodeGenerator } from './wifi-qr-code-generator';
 import { tool as randomPortGenerator } from './random-port-generator';
 import { tool as romanNumeralConverter } from './roman-numeral-converter';
+import { tool as schemaChecker } from './schema-checker';
+import { tool as seoChecker } from './seo-checker';
 import { tool as sqlPrettify } from './sql-prettify';
 import { tool as svgPlaceholderGenerator } from './svg-placeholder-generator';
 import { tool as temperatureConverter } from './temperature-converter';
@@ -141,6 +143,8 @@ const coreCategories: ToolCategory[] = [
       httpStatusCodes,
       jsonDiff,
       safelinkDecoder,
+      schemaChecker,
+      seoChecker,
     ],
   },
   {

--- a/src/tools/schema-checker/index.ts
+++ b/src/tools/schema-checker/index.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@vicons/tabler';
+import { FileCode } from '@vicons/tabler';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
@@ -7,7 +7,7 @@ export const tool = defineTool({
   description: 'Extract and validate JSON-LD structured data from HTML, with Schema.org-focused checks and Google-oriented guidance.',
   keywords: ['schema', 'schema.org', 'json-ld', 'structured data', 'seo', 'rich results', 'google', 'validator'],
   component: () => import('./schema-checker.vue'),
-  icon: Schema,
+  icon: FileCode,
   createdAt: new Date('2026-08-09'),
   privacy: {
     mode: 'local',

--- a/src/tools/schema-checker/index.ts
+++ b/src/tools/schema-checker/index.ts
@@ -1,0 +1,17 @@
+import { Schema } from '@vicons/tabler';
+import { defineTool } from '../tool';
+
+export const tool = defineTool({
+  name: 'Schema checker',
+  path: '/schema-checker',
+  description: 'Extract and validate JSON-LD structured data from HTML, with Schema.org-focused checks and Google-oriented guidance.',
+  keywords: ['schema', 'schema.org', 'json-ld', 'structured data', 'seo', 'rich results', 'google', 'validator'],
+  component: () => import('./schema-checker.vue'),
+  icon: Schema,
+  createdAt: new Date('2026-08-09'),
+  privacy: {
+    mode: 'local',
+    summary: 'Pasted HTML and JSON-LD are parsed locally in your browser.',
+  },
+  capabilities: ['text-input', 'clipboard', 'offline'],
+});

--- a/src/tools/schema-checker/schema-checker.service.test.ts
+++ b/src/tools/schema-checker/schema-checker.service.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { auditSchema, extractJsonLd } from './schema-checker.service';
+
+describe('schema checker', () => {
+  it('extracts JSON-LD from HTML', () => {
+    const html = '<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"ePlus"}</script>';
+    const result = extractJsonLd(html);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.blocks).toHaveLength(1);
+  });
+
+  it('reports malformed JSON-LD', () => {
+    const result = auditSchema('<script type="application/ld+json">{"@type":</script>');
+    expect(result.items.some(item => item.level === 'error')).toBe(true);
+  });
+
+  it('parses graph entities and warns about missing names', () => {
+    const result = auditSchema(JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [{ '@type': 'WebSite', name: 'Tools' }, { '@type': 'Organization' }],
+    }));
+    expect(result.entities).toHaveLength(2);
+    expect(result.items.some(item => item.message.includes('no name or headline'))).toBe(true);
+  });
+});

--- a/src/tools/schema-checker/schema-checker.service.test.ts
+++ b/src/tools/schema-checker/schema-checker.service.test.ts
@@ -17,7 +17,7 @@ describe('schema checker', () => {
   it('parses graph entities and warns about missing names', () => {
     const result = auditSchema(JSON.stringify({
       '@context': 'https://schema.org',
-      '@graph': [{ '@type': 'WebSite', name: 'Tools' }, { '@type': 'Organization' }],
+      '@graph': [{ '@type': 'WebSite', 'name': 'Tools' }, { '@type': 'Organization' }],
     }));
     expect(result.entities).toHaveLength(2);
     expect(result.items.some(item => item.message.includes('no name or headline'))).toBe(true);

--- a/src/tools/schema-checker/schema-checker.service.ts
+++ b/src/tools/schema-checker/schema-checker.service.ts
@@ -12,8 +12,12 @@ export interface SchemaEntity {
 }
 
 function asTypes(value: unknown): string[] {
-  if (typeof value === 'string') return [value];
-  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
   return [];
 }
 
@@ -23,30 +27,49 @@ function collectEntities(value: unknown, entities: SchemaEntity[]) {
     return;
   }
 
-  if (!value || typeof value !== 'object') return;
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
   const object = value as Record<string, unknown>;
   const types = asTypes(object['@type']);
-  if (types.length) entities.push({ type: types, raw: object });
-  if (Array.isArray(object['@graph'])) collectEntities(object['@graph'], entities);
+  if (types.length) {
+    entities.push({ type: types, raw: object });
+  }
+  if (Array.isArray(object['@graph'])) {
+    collectEntities(object['@graph'], entities);
+  }
 }
 
-export function extractJsonLd(input: string): { blocks: unknown[], parseErrors: string[] } {
+export function extractJsonLd(input: string): { blocks: unknown[]; parseErrors: string[] } {
   const trimmed = input.trim();
   const blocks: unknown[] = [];
   const parseErrors: string[] = [];
 
-  if (!trimmed) return { blocks, parseErrors };
+  if (!trimmed) {
+    return { blocks, parseErrors };
+  }
+
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-    try { blocks.push(JSON.parse(trimmed)); }
-    catch (error) { parseErrors.push(error instanceof Error ? error.message : 'Invalid JSON-LD'); }
+    try {
+      blocks.push(JSON.parse(trimmed));
+    }
+    catch (error) {
+      parseErrors.push(error instanceof Error ? error.message : 'Invalid JSON-LD');
+    }
     return { blocks, parseErrors };
   }
 
   const document = new DOMParser().parseFromString(input, 'text/html');
   document.querySelectorAll('script[type="application/ld+json"]').forEach((node, index) => {
-    try { blocks.push(JSON.parse(node.textContent ?? '')); }
-    catch (error) { parseErrors.push(`Block ${index + 1}: ${error instanceof Error ? error.message : 'Invalid JSON-LD'}`); }
+    try {
+      blocks.push(JSON.parse(node.textContent ?? ''));
+    }
+    catch (error) {
+      parseErrors.push(`Block ${index + 1}: ${error instanceof Error ? error.message : 'Invalid JSON-LD'}`);
+    }
   });
+
   return { blocks, parseErrors };
 }
 
@@ -57,25 +80,40 @@ export function auditSchema(input: string) {
   const items: SchemaAuditItem[] = [];
 
   parseErrors.forEach(message => items.push({ level: 'error', message }));
-  if (!blocks.length && !parseErrors.length) items.push({ level: 'warning', message: 'No JSON-LD blocks found.' });
-  if (blocks.length) items.push({ level: 'passed', message: `Found ${blocks.length} JSON-LD block${blocks.length === 1 ? '' : 's'}.` });
+  if (!blocks.length && !parseErrors.length) {
+    items.push({ level: 'warning', message: 'No JSON-LD blocks found.' });
+  }
+  if (blocks.length) {
+    items.push({ level: 'passed', message: `Found ${blocks.length} JSON-LD block${blocks.length === 1 ? '' : 's'}.` });
+  }
 
   for (const [index, block] of blocks.entries()) {
-    if (!block || typeof block !== 'object') continue;
+    if (!block || typeof block !== 'object') {
+      continue;
+    }
     const object = block as Record<string, unknown>;
-    if (!('@context' in object)) items.push({ level: 'warning', message: 'Missing @context on top-level JSON-LD block.', path: `block[${index}]` });
+    if (!('@context' in object)) {
+      items.push({ level: 'warning', message: 'Missing @context on top-level JSON-LD block.', path: `block[${index}]` });
+    }
   }
 
   for (const [index, entity] of entities.entries()) {
     const path = `entity[${index}] (${entity.type.join(', ')})`;
-    if (!entity.raw.name && !entity.raw.headline) items.push({ level: 'warning', message: 'Entity has no name or headline.', path });
+    if (!entity.raw.name && !entity.raw.headline) {
+      items.push({ level: 'warning', message: 'Entity has no name or headline.', path });
+    }
     if (['Article', 'NewsArticle', 'BlogPosting', 'Product', 'Organization', 'LocalBusiness'].some(type => entity.type.includes(type)) && !entity.raw.image) {
       items.push({ level: 'info', message: 'Consider adding image for richer search presentation.', path });
     }
-    if (entity.raw.url && typeof entity.raw.url !== 'string') items.push({ level: 'warning', message: 'url should normally be a string URL.', path });
+    if (entity.raw.url && typeof entity.raw.url !== 'string') {
+      items.push({ level: 'warning', message: 'url should normally be a string URL.', path });
+    }
   }
 
-  if (entities.length) items.push({ level: 'passed', message: `Parsed ${entities.length} typed schema entit${entities.length === 1 ? 'y' : 'ies'}.` });
+  if (entities.length) {
+    items.push({ level: 'passed', message: `Parsed ${entities.length} typed schema entit${entities.length === 1 ? 'y' : 'ies'}.` });
+  }
   items.push({ level: 'info', message: 'Schema.org validity does not guarantee eligibility for Google rich results.' });
+
   return { blocks, entities, items };
 }

--- a/src/tools/schema-checker/schema-checker.service.ts
+++ b/src/tools/schema-checker/schema-checker.service.ts
@@ -1,0 +1,81 @@
+export type AuditLevel = 'error' | 'warning' | 'passed' | 'info';
+
+export interface SchemaAuditItem {
+  level: AuditLevel
+  message: string
+  path?: string
+}
+
+export interface SchemaEntity {
+  type: string[]
+  raw: Record<string, unknown>
+}
+
+function asTypes(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
+  return [];
+}
+
+function collectEntities(value: unknown, entities: SchemaEntity[]) {
+  if (Array.isArray(value)) {
+    value.forEach(item => collectEntities(item, entities));
+    return;
+  }
+
+  if (!value || typeof value !== 'object') return;
+  const object = value as Record<string, unknown>;
+  const types = asTypes(object['@type']);
+  if (types.length) entities.push({ type: types, raw: object });
+  if (Array.isArray(object['@graph'])) collectEntities(object['@graph'], entities);
+}
+
+export function extractJsonLd(input: string): { blocks: unknown[], parseErrors: string[] } {
+  const trimmed = input.trim();
+  const blocks: unknown[] = [];
+  const parseErrors: string[] = [];
+
+  if (!trimmed) return { blocks, parseErrors };
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try { blocks.push(JSON.parse(trimmed)); }
+    catch (error) { parseErrors.push(error instanceof Error ? error.message : 'Invalid JSON-LD'); }
+    return { blocks, parseErrors };
+  }
+
+  const document = new DOMParser().parseFromString(input, 'text/html');
+  document.querySelectorAll('script[type="application/ld+json"]').forEach((node, index) => {
+    try { blocks.push(JSON.parse(node.textContent ?? '')); }
+    catch (error) { parseErrors.push(`Block ${index + 1}: ${error instanceof Error ? error.message : 'Invalid JSON-LD'}`); }
+  });
+  return { blocks, parseErrors };
+}
+
+export function auditSchema(input: string) {
+  const { blocks, parseErrors } = extractJsonLd(input);
+  const entities: SchemaEntity[] = [];
+  blocks.forEach(block => collectEntities(block, entities));
+  const items: SchemaAuditItem[] = [];
+
+  parseErrors.forEach(message => items.push({ level: 'error', message }));
+  if (!blocks.length && !parseErrors.length) items.push({ level: 'warning', message: 'No JSON-LD blocks found.' });
+  if (blocks.length) items.push({ level: 'passed', message: `Found ${blocks.length} JSON-LD block${blocks.length === 1 ? '' : 's'}.` });
+
+  for (const [index, block] of blocks.entries()) {
+    if (!block || typeof block !== 'object') continue;
+    const object = block as Record<string, unknown>;
+    if (!('@context' in object)) items.push({ level: 'warning', message: 'Missing @context on top-level JSON-LD block.', path: `block[${index}]` });
+  }
+
+  for (const [index, entity] of entities.entries()) {
+    const path = `entity[${index}] (${entity.type.join(', ')})`;
+    if (!entity.raw.name && !entity.raw.headline) items.push({ level: 'warning', message: 'Entity has no name or headline.', path });
+    if (['Article', 'NewsArticle', 'BlogPosting', 'Product', 'Organization', 'LocalBusiness'].some(type => entity.type.includes(type)) && !entity.raw.image) {
+      items.push({ level: 'info', message: 'Consider adding image for richer search presentation.', path });
+    }
+    if (entity.raw.url && typeof entity.raw.url !== 'string') items.push({ level: 'warning', message: 'url should normally be a string URL.', path });
+  }
+
+  if (entities.length) items.push({ level: 'passed', message: `Parsed ${entities.length} typed schema entit${entities.length === 1 ? 'y' : 'ies'}.` });
+  items.push({ level: 'info', message: 'Schema.org validity does not guarantee eligibility for Google rich results.' });
+  return { blocks, entities, items };
+}

--- a/src/tools/schema-checker/schema-checker.vue
+++ b/src/tools/schema-checker/schema-checker.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useCopy } from '@/composable/copy';
 import { auditSchema } from './schema-checker.service';
+import { useCopy } from '@/composable/copy';
 
 const input = ref('');
 const result = computed(() => auditSchema(input.value));
@@ -11,9 +11,15 @@ const report = computed(() => JSON.stringify({
 const { copy } = useCopy({ source: report, text: 'Schema audit report copied to the clipboard' });
 
 function levelType(level: string) {
-  if (level === 'error') return 'error';
-  if (level === 'warning') return 'warning';
-  if (level === 'passed') return 'success';
+  if (level === 'error') {
+    return 'error';
+  }
+  if (level === 'warning') {
+    return 'warning';
+  }
+  if (level === 'passed') {
+    return 'success';
+  }
   return 'info';
 }
 </script>
@@ -48,7 +54,9 @@ function levelType(level: string) {
       </c-card>
 
       <div flex justify-center>
-        <c-button @click="copy()">Copy JSON report</c-button>
+        <c-button @click="copy()">
+          Copy JSON report
+        </c-button>
       </div>
     </div>
   </c-card>

--- a/src/tools/schema-checker/schema-checker.vue
+++ b/src/tools/schema-checker/schema-checker.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { useCopy } from '@/composable/copy';
+import { auditSchema } from './schema-checker.service';
+
+const input = ref('');
+const result = computed(() => auditSchema(input.value));
+const report = computed(() => JSON.stringify({
+  summary: result.value.items,
+  entities: result.value.entities.map(entity => ({ type: entity.type, raw: entity.raw })),
+}, null, 2));
+const { copy } = useCopy({ source: report, text: 'Schema audit report copied to the clipboard' });
+
+function levelType(level: string) {
+  if (level === 'error') return 'error';
+  if (level === 'warning') return 'warning';
+  if (level === 'passed') return 'success';
+  return 'info';
+}
+</script>
+
+<template>
+  <c-card title="Schema checker">
+    <c-input-text
+      v-model:value="input"
+      multiline
+      rows="14"
+      raw-text
+      label="HTML or JSON-LD"
+      placeholder="Paste a full HTML document or a JSON-LD object here..."
+      mb-4
+    />
+
+    <div v-if="input.trim()" flex flex-col gap-3>
+      <n-alert
+        v-for="(item, index) in result.items"
+        :key="`${item.level}-${index}`"
+        :type="levelType(item.level)"
+        :title="item.path || item.level.toUpperCase()"
+      >
+        {{ item.message }}
+      </n-alert>
+
+      <c-card v-if="result.entities.length" title="Detected entities">
+        <div v-for="(entity, index) in result.entities" :key="index" mb-3>
+          <strong>{{ entity.type.join(', ') }}</strong>
+          <pre mt-2 overflow-auto>{{ JSON.stringify(entity.raw, null, 2) }}</pre>
+        </div>
+      </c-card>
+
+      <div flex justify-center>
+        <c-button @click="copy()">Copy JSON report</c-button>
+      </div>
+    </div>
+  </c-card>
+</template>

--- a/src/tools/seo-checker/index.ts
+++ b/src/tools/seo-checker/index.ts
@@ -1,0 +1,17 @@
+import { Search } from '@vicons/tabler';
+import { defineTool } from '../tool';
+
+export const tool = defineTool({
+  name: 'SEO checker',
+  path: '/seo-checker',
+  description: 'Audit pasted HTML for essential technical SEO, social metadata, headings, canonicals, robots and image accessibility.',
+  keywords: ['seo', 'audit', 'meta', 'title', 'description', 'canonical', 'robots', 'open graph', 'twitter card', 'headings'],
+  component: () => import('./seo-checker.vue'),
+  icon: Search,
+  createdAt: new Date('2026-08-09'),
+  privacy: {
+    mode: 'local',
+    summary: 'Pasted HTML is audited entirely in your browser and is never uploaded.',
+  },
+  capabilities: ['text-input', 'clipboard', 'offline'],
+});

--- a/src/tools/seo-checker/seo-checker.service.test.ts
+++ b/src/tools/seo-checker/seo-checker.service.test.ts
@@ -3,7 +3,7 @@ import { auditSeo } from './seo-checker.service';
 
 describe('seo checker', () => {
   it('passes core metadata for a healthy page', () => {
-    const items = auditSeo(`<!doctype html><html><head><title>Useful developer tools for everyday debugging</title><meta name="description" content="A practical collection of developer utilities for debugging, conversion, validation and browser-local workflows."><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="robots" content="index,follow"><link rel="canonical" href="https://tools.eplus.dev/test"><meta property="og:title" content="Tools"><meta property="og:description" content="Developer tools"><meta property="og:image" content="https://tools.eplus.dev/og.png"><meta name="twitter:card" content="summary_large_image"></head><body><h1>Tools</h1><img src="x.png" alt="Example"></body></html>`);
+    const items = auditSeo('<!doctype html><html><head><title>Useful developer tools for everyday debugging</title><meta name="description" content="A practical collection of developer utilities for debugging, conversion, validation and browser-local workflows."><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="robots" content="index,follow"><link rel="canonical" href="https://tools.eplus.dev/test"><meta property="og:title" content="Tools"><meta property="og:description" content="Developer tools"><meta property="og:image" content="https://tools.eplus.dev/og.png"><meta name="twitter:card" content="summary_large_image"></head><body><h1>Tools</h1><img src="x.png" alt="Example"></body></html>');
     expect(items.some(item => item.level === 'error')).toBe(false);
     expect(items.some(item => item.message === 'One H1 heading found.')).toBe(true);
   });

--- a/src/tools/seo-checker/seo-checker.service.test.ts
+++ b/src/tools/seo-checker/seo-checker.service.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { auditSeo } from './seo-checker.service';
+
+describe('seo checker', () => {
+  it('passes core metadata for a healthy page', () => {
+    const items = auditSeo(`<!doctype html><html><head><title>Useful developer tools for everyday debugging</title><meta name="description" content="A practical collection of developer utilities for debugging, conversion, validation and browser-local workflows."><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="robots" content="index,follow"><link rel="canonical" href="https://tools.eplus.dev/test"><meta property="og:title" content="Tools"><meta property="og:description" content="Developer tools"><meta property="og:image" content="https://tools.eplus.dev/og.png"><meta name="twitter:card" content="summary_large_image"></head><body><h1>Tools</h1><img src="x.png" alt="Example"></body></html>`);
+    expect(items.some(item => item.level === 'error')).toBe(false);
+    expect(items.some(item => item.message === 'One H1 heading found.')).toBe(true);
+  });
+
+  it('detects critical missing SEO fields', () => {
+    const items = auditSeo('<html><head></head><body><p>Hello</p></body></html>');
+    expect(items.some(item => item.message.includes('Missing <title>'))).toBe(true);
+    expect(items.some(item => item.message.includes('No H1'))).toBe(true);
+  });
+
+  it('detects noindex and duplicate canonical links', () => {
+    const items = auditSeo('<html><head><title>Test page title that is long enough for audit</title><meta name="robots" content="noindex"><link rel="canonical" href="https://a.test"><link rel="canonical" href="https://b.test"></head><body><h1>Test</h1></body></html>');
+    expect(items.some(item => item.message.includes('noindex'))).toBe(true);
+    expect(items.some(item => item.message.includes('2 canonical'))).toBe(true);
+  });
+});

--- a/src/tools/seo-checker/seo-checker.service.ts
+++ b/src/tools/seo-checker/seo-checker.service.ts
@@ -1,0 +1,72 @@
+export type SeoAuditLevel = 'error' | 'warning' | 'passed' | 'info';
+
+export interface SeoAuditItem {
+  level: SeoAuditLevel
+  category: string
+  message: string
+}
+
+function metaContent(document: Document, selector: string) {
+  return document.querySelector<HTMLMetaElement>(selector)?.content.trim() ?? '';
+}
+
+export function auditSeo(html: string): SeoAuditItem[] {
+  const items: SeoAuditItem[] = [];
+  if (!html.trim()) return items;
+
+  const document = new DOMParser().parseFromString(html, 'text/html');
+  const title = document.querySelector('title')?.textContent?.trim() ?? '';
+  const description = metaContent(document, 'meta[name="description"]');
+  const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href ?? '';
+  const robots = metaContent(document, 'meta[name="robots"]');
+  const viewport = metaContent(document, 'meta[name="viewport"]');
+  const h1Count = document.querySelectorAll('h1').length;
+  const images = [...document.querySelectorAll('img')];
+  const missingAlt = images.filter(image => !image.hasAttribute('alt')).length;
+  const jsonLdCount = document.querySelectorAll('script[type="application/ld+json"]').length;
+  const ogTitle = metaContent(document, 'meta[property="og:title"]');
+  const ogDescription = metaContent(document, 'meta[property="og:description"]');
+  const ogImage = metaContent(document, 'meta[property="og:image"]');
+  const twitterCard = metaContent(document, 'meta[name="twitter:card"]');
+
+  if (!title) items.push({ level: 'error', category: 'Metadata', message: 'Missing <title>.' });
+  else if (title.length < 20 || title.length > 65) items.push({ level: 'warning', category: 'Metadata', message: `Title length is ${title.length} characters; review for search snippet readability.` });
+  else items.push({ level: 'passed', category: 'Metadata', message: `Title is present (${title.length} characters).` });
+
+  if (!description) items.push({ level: 'warning', category: 'Metadata', message: 'Missing meta description.' });
+  else if (description.length < 70 || description.length > 170) items.push({ level: 'warning', category: 'Metadata', message: `Meta description length is ${description.length} characters.` });
+  else items.push({ level: 'passed', category: 'Metadata', message: 'Meta description is present.' });
+
+  if (!canonical) items.push({ level: 'warning', category: 'Indexing', message: 'Missing canonical link.' });
+  else items.push({ level: 'passed', category: 'Indexing', message: 'Canonical link is present.' });
+
+  if (/noindex/i.test(robots)) items.push({ level: 'warning', category: 'Indexing', message: 'robots meta contains noindex.' });
+  else items.push({ level: 'passed', category: 'Indexing', message: robots ? `robots meta: ${robots}` : 'No page-level noindex directive detected.' });
+
+  if (!viewport) items.push({ level: 'warning', category: 'Mobile', message: 'Missing viewport meta tag.' });
+  else items.push({ level: 'passed', category: 'Mobile', message: 'Viewport meta tag is present.' });
+
+  if (h1Count === 0) items.push({ level: 'error', category: 'Content', message: 'No H1 heading found.' });
+  else if (h1Count > 1) items.push({ level: 'info', category: 'Content', message: `Found ${h1Count} H1 headings; verify the hierarchy is intentional.` });
+  else items.push({ level: 'passed', category: 'Content', message: 'One H1 heading found.' });
+
+  if (missingAlt) items.push({ level: 'warning', category: 'Images', message: `${missingAlt} of ${images.length} images are missing an alt attribute.` });
+  else if (images.length) items.push({ level: 'passed', category: 'Images', message: 'All images include an alt attribute.' });
+
+  if (ogTitle && ogDescription && ogImage) items.push({ level: 'passed', category: 'Social', message: 'Core Open Graph metadata is present.' });
+  else items.push({ level: 'warning', category: 'Social', message: 'Open Graph metadata is incomplete; check og:title, og:description and og:image.' });
+
+  if (twitterCard) items.push({ level: 'passed', category: 'Social', message: `Twitter card configured as ${twitterCard}.` });
+  else items.push({ level: 'info', category: 'Social', message: 'No twitter:card metadata found.' });
+
+  if (jsonLdCount) items.push({ level: 'passed', category: 'Structured data', message: `Found ${jsonLdCount} JSON-LD block${jsonLdCount === 1 ? '' : 's'}.` });
+  else items.push({ level: 'info', category: 'Structured data', message: 'No JSON-LD structured data found.' });
+
+  const duplicateDescriptions = document.querySelectorAll('meta[name="description"]').length;
+  if (duplicateDescriptions > 1) items.push({ level: 'warning', category: 'Metadata', message: `Found ${duplicateDescriptions} meta description tags.` });
+
+  const duplicateCanonicals = document.querySelectorAll('link[rel="canonical"]').length;
+  if (duplicateCanonicals > 1) items.push({ level: 'warning', category: 'Indexing', message: `Found ${duplicateCanonicals} canonical links.` });
+
+  return items;
+}

--- a/src/tools/seo-checker/seo-checker.service.ts
+++ b/src/tools/seo-checker/seo-checker.service.ts
@@ -12,7 +12,9 @@ function metaContent(document: Document, selector: string) {
 
 export function auditSeo(html: string): SeoAuditItem[] {
   const items: SeoAuditItem[] = [];
-  if (!html.trim()) return items;
+  if (!html.trim()) {
+    return items;
+  }
 
   const document = new DOMParser().parseFromString(html, 'text/html');
   const title = document.querySelector('title')?.textContent?.trim() ?? '';
@@ -29,44 +31,94 @@ export function auditSeo(html: string): SeoAuditItem[] {
   const ogImage = metaContent(document, 'meta[property="og:image"]');
   const twitterCard = metaContent(document, 'meta[name="twitter:card"]');
 
-  if (!title) items.push({ level: 'error', category: 'Metadata', message: 'Missing <title>.' });
-  else if (title.length < 20 || title.length > 65) items.push({ level: 'warning', category: 'Metadata', message: `Title length is ${title.length} characters; review for search snippet readability.` });
-  else items.push({ level: 'passed', category: 'Metadata', message: `Title is present (${title.length} characters).` });
+  if (!title) {
+    items.push({ level: 'error', category: 'Metadata', message: 'Missing <title>.' });
+  }
+  else if (title.length < 20 || title.length > 65) {
+    items.push({ level: 'warning', category: 'Metadata', message: `Title length is ${title.length} characters; review for search snippet readability.` });
+  }
+  else {
+    items.push({ level: 'passed', category: 'Metadata', message: `Title is present (${title.length} characters).` });
+  }
 
-  if (!description) items.push({ level: 'warning', category: 'Metadata', message: 'Missing meta description.' });
-  else if (description.length < 70 || description.length > 170) items.push({ level: 'warning', category: 'Metadata', message: `Meta description length is ${description.length} characters.` });
-  else items.push({ level: 'passed', category: 'Metadata', message: 'Meta description is present.' });
+  if (!description) {
+    items.push({ level: 'warning', category: 'Metadata', message: 'Missing meta description.' });
+  }
+  else if (description.length < 70 || description.length > 170) {
+    items.push({ level: 'warning', category: 'Metadata', message: `Meta description length is ${description.length} characters.` });
+  }
+  else {
+    items.push({ level: 'passed', category: 'Metadata', message: 'Meta description is present.' });
+  }
 
-  if (!canonical) items.push({ level: 'warning', category: 'Indexing', message: 'Missing canonical link.' });
-  else items.push({ level: 'passed', category: 'Indexing', message: 'Canonical link is present.' });
+  if (!canonical) {
+    items.push({ level: 'warning', category: 'Indexing', message: 'Missing canonical link.' });
+  }
+  else {
+    items.push({ level: 'passed', category: 'Indexing', message: 'Canonical link is present.' });
+  }
 
-  if (/noindex/i.test(robots)) items.push({ level: 'warning', category: 'Indexing', message: 'robots meta contains noindex.' });
-  else items.push({ level: 'passed', category: 'Indexing', message: robots ? `robots meta: ${robots}` : 'No page-level noindex directive detected.' });
+  if (/noindex/i.test(robots)) {
+    items.push({ level: 'warning', category: 'Indexing', message: 'robots meta contains noindex.' });
+  }
+  else {
+    items.push({ level: 'passed', category: 'Indexing', message: robots ? `robots meta: ${robots}` : 'No page-level noindex directive detected.' });
+  }
 
-  if (!viewport) items.push({ level: 'warning', category: 'Mobile', message: 'Missing viewport meta tag.' });
-  else items.push({ level: 'passed', category: 'Mobile', message: 'Viewport meta tag is present.' });
+  if (!viewport) {
+    items.push({ level: 'warning', category: 'Mobile', message: 'Missing viewport meta tag.' });
+  }
+  else {
+    items.push({ level: 'passed', category: 'Mobile', message: 'Viewport meta tag is present.' });
+  }
 
-  if (h1Count === 0) items.push({ level: 'error', category: 'Content', message: 'No H1 heading found.' });
-  else if (h1Count > 1) items.push({ level: 'info', category: 'Content', message: `Found ${h1Count} H1 headings; verify the hierarchy is intentional.` });
-  else items.push({ level: 'passed', category: 'Content', message: 'One H1 heading found.' });
+  if (h1Count === 0) {
+    items.push({ level: 'error', category: 'Content', message: 'No H1 heading found.' });
+  }
+  else if (h1Count > 1) {
+    items.push({ level: 'info', category: 'Content', message: `Found ${h1Count} H1 headings; verify the hierarchy is intentional.` });
+  }
+  else {
+    items.push({ level: 'passed', category: 'Content', message: 'One H1 heading found.' });
+  }
 
-  if (missingAlt) items.push({ level: 'warning', category: 'Images', message: `${missingAlt} of ${images.length} images are missing an alt attribute.` });
-  else if (images.length) items.push({ level: 'passed', category: 'Images', message: 'All images include an alt attribute.' });
+  if (missingAlt) {
+    items.push({ level: 'warning', category: 'Images', message: `${missingAlt} of ${images.length} images are missing an alt attribute.` });
+  }
+  else if (images.length) {
+    items.push({ level: 'passed', category: 'Images', message: 'All images include an alt attribute.' });
+  }
 
-  if (ogTitle && ogDescription && ogImage) items.push({ level: 'passed', category: 'Social', message: 'Core Open Graph metadata is present.' });
-  else items.push({ level: 'warning', category: 'Social', message: 'Open Graph metadata is incomplete; check og:title, og:description and og:image.' });
+  if (ogTitle && ogDescription && ogImage) {
+    items.push({ level: 'passed', category: 'Social', message: 'Core Open Graph metadata is present.' });
+  }
+  else {
+    items.push({ level: 'warning', category: 'Social', message: 'Open Graph metadata is incomplete; check og:title, og:description and og:image.' });
+  }
 
-  if (twitterCard) items.push({ level: 'passed', category: 'Social', message: `Twitter card configured as ${twitterCard}.` });
-  else items.push({ level: 'info', category: 'Social', message: 'No twitter:card metadata found.' });
+  if (twitterCard) {
+    items.push({ level: 'passed', category: 'Social', message: `Twitter card configured as ${twitterCard}.` });
+  }
+  else {
+    items.push({ level: 'info', category: 'Social', message: 'No twitter:card metadata found.' });
+  }
 
-  if (jsonLdCount) items.push({ level: 'passed', category: 'Structured data', message: `Found ${jsonLdCount} JSON-LD block${jsonLdCount === 1 ? '' : 's'}.` });
-  else items.push({ level: 'info', category: 'Structured data', message: 'No JSON-LD structured data found.' });
+  if (jsonLdCount) {
+    items.push({ level: 'passed', category: 'Structured data', message: `Found ${jsonLdCount} JSON-LD block${jsonLdCount === 1 ? '' : 's'}.` });
+  }
+  else {
+    items.push({ level: 'info', category: 'Structured data', message: 'No JSON-LD structured data found.' });
+  }
 
   const duplicateDescriptions = document.querySelectorAll('meta[name="description"]').length;
-  if (duplicateDescriptions > 1) items.push({ level: 'warning', category: 'Metadata', message: `Found ${duplicateDescriptions} meta description tags.` });
+  if (duplicateDescriptions > 1) {
+    items.push({ level: 'warning', category: 'Metadata', message: `Found ${duplicateDescriptions} meta description tags.` });
+  }
 
   const duplicateCanonicals = document.querySelectorAll('link[rel="canonical"]').length;
-  if (duplicateCanonicals > 1) items.push({ level: 'warning', category: 'Indexing', message: `Found ${duplicateCanonicals} canonical links.` });
+  if (duplicateCanonicals > 1) {
+    items.push({ level: 'warning', category: 'Indexing', message: `Found ${duplicateCanonicals} canonical links.` });
+  }
 
   return items;
 }

--- a/src/tools/seo-checker/seo-checker.vue
+++ b/src/tools/seo-checker/seo-checker.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useCopy } from '@/composable/copy';
 import { auditSeo } from './seo-checker.service';
+import { useCopy } from '@/composable/copy';
 
 const input = ref('');
 const items = computed(() => auditSeo(input.value));
@@ -12,9 +12,15 @@ const report = computed(() => JSON.stringify({ audit: items.value }, null, 2));
 const { copy } = useCopy({ source: report, text: 'SEO audit report copied to the clipboard' });
 
 function levelType(level: string) {
-  if (level === 'error') return 'error';
-  if (level === 'warning') return 'warning';
-  if (level === 'passed') return 'success';
+  if (level === 'error') {
+    return 'error';
+  }
+  if (level === 'warning') {
+    return 'warning';
+  }
+  if (level === 'passed') {
+    return 'success';
+  }
   return 'info';
 }
 </script>
@@ -45,7 +51,9 @@ function levelType(level: string) {
       </c-card>
 
       <div flex justify-center>
-        <c-button @click="copy()">Copy JSON report</c-button>
+        <c-button @click="copy()">
+          Copy JSON report
+        </c-button>
       </div>
     </div>
   </c-card>

--- a/src/tools/seo-checker/seo-checker.vue
+++ b/src/tools/seo-checker/seo-checker.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { useCopy } from '@/composable/copy';
+import { auditSeo } from './seo-checker.service';
+
+const input = ref('');
+const items = computed(() => auditSeo(input.value));
+const grouped = computed(() => items.value.reduce<Record<string, typeof items.value>>((groups, item) => {
+  (groups[item.category] ||= []).push(item);
+  return groups;
+}, {}));
+const report = computed(() => JSON.stringify({ audit: items.value }, null, 2));
+const { copy } = useCopy({ source: report, text: 'SEO audit report copied to the clipboard' });
+
+function levelType(level: string) {
+  if (level === 'error') return 'error';
+  if (level === 'warning') return 'warning';
+  if (level === 'passed') return 'success';
+  return 'info';
+}
+</script>
+
+<template>
+  <c-card title="SEO checker">
+    <c-input-text
+      v-model:value="input"
+      multiline
+      rows="16"
+      raw-text
+      label="Page HTML"
+      placeholder="Paste the rendered or server HTML you want to audit..."
+      mb-4
+    />
+
+    <div v-if="input.trim()" flex flex-col gap-4>
+      <c-card v-for="(categoryItems, category) in grouped" :key="category" :title="category">
+        <n-alert
+          v-for="(item, index) in categoryItems"
+          :key="`${category}-${index}`"
+          :type="levelType(item.level)"
+          :title="item.level.toUpperCase()"
+          mb-2
+        >
+          {{ item.message }}
+        </n-alert>
+      </c-card>
+
+      <div flex justify-center>
+        <c-button @click="copy()">Copy JSON report</c-button>
+      </div>
+    </div>
+  </c-card>
+</template>


### PR DESCRIPTION
Adds two browser-local auditing utilities:

- Schema checker
  - accepts pasted HTML or raw JSON-LD
  - extracts application/ld+json blocks
  - reports JSON parse errors, typed entities, missing @context/name/headline, image guidance and URL shape issues
  - explicitly distinguishes general Schema.org validation from Google rich-result eligibility
  - exports a JSON report
- SEO checker
  - audits title, meta description, canonical, robots/noindex, viewport, H1 count, image alt attributes, Open Graph, Twitter card, JSON-LD presence, duplicate descriptions and duplicate canonicals
  - groups findings into error/warning/passed/info instead of a synthetic score
  - exports a JSON report

Both tools run fully in the browser and are registered in the Web category so sitemap and AI-readable catalog generation will include them automatically. Includes focused unit tests.