### PR TITLE
fix: refresh stale PWA cache after deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,23 @@
+[[headers]]
+  for = "/sw.js"
+  [headers.values]
+    Cache-Control = "no-cache, no-store, must-revalidate"
+
+[[headers]]
+  for = "/index.html"
+  [headers.values]
+    Cache-Control = "no-cache, no-store, must-revalidate"
+
+[[headers]]
+  for = "/manifest.webmanifest"
+  [headers.values]
+    Cache-Control = "no-cache, no-store, must-revalidate"
+
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
 [[redirects]]
   from = "/vietqr-bank-logo/cdn/*"
   to = "https://cdn.vietqr.io/img/:splat"

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,49 @@ import router from './router';
 import { installGoogleAnalytics } from './plugins/google-analytics.plugin';
 import { i18nPlugin } from './plugins/i18n.plugin';
 
-registerSW();
+const SERVICE_WORKER_UPDATE_INTERVAL_MS = 15 * 60 * 1000;
+
+registerSW({
+  immediate: true,
+  onRegisteredSW(swUrl, registration) {
+    if (!registration) {
+      return;
+    }
+
+    const checkForUpdate = async () => {
+      if (!navigator.onLine || registration.installing) {
+        return;
+      }
+
+      try {
+        const response = await fetch(swUrl, {
+          cache: 'no-store',
+          headers: {
+            'cache-control': 'no-cache',
+          },
+        });
+
+        if (response.ok) {
+          await registration.update();
+        }
+      }
+      catch {
+        // Keep the current app available if the update check is temporarily offline.
+      }
+    };
+
+    void checkForUpdate();
+    window.setInterval(() => {
+      void checkForUpdate();
+    }, SERVICE_WORKER_UPDATE_INTERVAL_MS);
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        void checkForUpdate();
+      }
+    });
+  },
+});
 installGoogleAnalytics({ router });
 
 const app = createApp(App);


### PR DESCRIPTION
## What changed
- register the PWA service worker immediately instead of waiting for the default timing
- explicitly check `sw.js` without browser cache on startup, every 15 minutes, and when the tab becomes visible again
- keep the existing `autoUpdate` behavior so a newly activated worker can take control without asking users to clear site data
- mark `sw.js`, `index.html`, and `manifest.webmanifest` as non-cacheable in the browser
- keep hashed `/assets/*` files immutable for long-term caching

## Why
The normal browser profile can remain controlled by an older service worker and its precached application shell, while an incognito profile has no existing service worker/cache and therefore sees the latest deploy immediately. This makes the site self-refresh its PWA registration and avoids stale entry-point files without removing PWA support.