### PR TITLE
feat: check deploy version on app entry

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,6 +14,11 @@
     Cache-Control = "no-cache, no-store, must-revalidate"
 
 [[headers]]
+  for = "/version.json"
+  [headers.values]
+    Cache-Control = "no-cache, no-store, must-revalidate"
+
+[[headers]]
   for = "/assets/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ async function checkDeployVersion() {
       cache: 'no-store',
       headers: {
         'cache-control': 'no-cache',
-        pragma: 'no-cache',
+        'pragma': 'no-cache',
       },
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,8 +49,18 @@ async function checkDeployVersion() {
       return;
     }
 
+    if (!('serviceWorker' in navigator)) {
+      window.location.reload();
+      return;
+    }
+
     const registration = await navigator.serviceWorker.getRegistration(import.meta.env.BASE_URL);
-    await registration?.update();
+    if (!registration) {
+      window.location.reload();
+      return;
+    }
+
+    await registration.update();
   }
   catch {
     // Keep the current app usable if the version endpoint is temporarily unavailable.

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,49 +14,57 @@ import router from './router';
 import { installGoogleAnalytics } from './plugins/google-analytics.plugin';
 import { i18nPlugin } from './plugins/i18n.plugin';
 
-const SERVICE_WORKER_UPDATE_INTERVAL_MS = 15 * 60 * 1000;
+const CURRENT_DEPLOY_VERSION = import.meta.env.VITE_DEPLOY_VERSION;
+const VERSION_MANIFEST_URL = `${import.meta.env.BASE_URL}version.json`;
 
-registerSW({
-  immediate: true,
-  onRegisteredSW(swUrl, registration) {
-    if (!registration) {
+registerSW({ immediate: true });
+
+let versionCheckRunning = false;
+
+async function checkDeployVersion() {
+  if (versionCheckRunning || !navigator.onLine) {
+    return;
+  }
+
+  versionCheckRunning = true;
+
+  try {
+    const versionUrl = new URL(VERSION_MANIFEST_URL, window.location.origin);
+    versionUrl.searchParams.set('_', Date.now().toString());
+
+    const response = await fetch(versionUrl, {
+      cache: 'no-store',
+      headers: {
+        'cache-control': 'no-cache',
+        pragma: 'no-cache',
+      },
+    });
+
+    if (!response.ok) {
       return;
     }
 
-    const checkForUpdate = async () => {
-      if (!navigator.onLine || registration.installing) {
-        return;
-      }
+    const manifest = await response.json() as { version?: string };
+    if (!manifest.version || manifest.version === CURRENT_DEPLOY_VERSION) {
+      return;
+    }
 
-      try {
-        const response = await fetch(swUrl, {
-          cache: 'no-store',
-          headers: {
-            'cache-control': 'no-cache',
-          },
-        });
+    const registration = await navigator.serviceWorker.getRegistration(import.meta.env.BASE_URL);
+    await registration?.update();
+  }
+  catch {
+    // Keep the current app usable if the version endpoint is temporarily unavailable.
+  }
+  finally {
+    versionCheckRunning = false;
+  }
+}
 
-        if (response.ok) {
-          await registration.update();
-        }
-      }
-      catch {
-        // Keep the current app available if the update check is temporarily offline.
-      }
-    };
-
-    void checkForUpdate();
-    window.setInterval(() => {
-      void checkForUpdate();
-    }, SERVICE_WORKER_UPDATE_INTERVAL_MS);
-
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') {
-        void checkForUpdate();
-      }
-    });
-  },
+void checkDeployVersion();
+window.addEventListener('pageshow', () => {
+  void checkDeployVersion();
 });
+
 installGoogleAnalytics({ router });
 
 const app = createApp(App);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,62 +13,21 @@ import App from './App.vue';
 import router from './router';
 import { installGoogleAnalytics } from './plugins/google-analytics.plugin';
 import { i18nPlugin } from './plugins/i18n.plugin';
-
-const CURRENT_DEPLOY_VERSION = import.meta.env.VITE_DEPLOY_VERSION;
-const VERSION_MANIFEST_URL = `${import.meta.env.BASE_URL}version.json`;
+import { createDeployVersionChecker } from './modules/app-version/deploy-version';
 
 registerSW({ immediate: true });
 
-let versionCheckRunning = false;
-
-async function checkDeployVersion() {
-  if (versionCheckRunning || !navigator.onLine) {
-    return;
-  }
-
-  versionCheckRunning = true;
-
-  try {
-    const versionUrl = new URL(VERSION_MANIFEST_URL, window.location.origin);
-    versionUrl.searchParams.set('_', Date.now().toString());
-
-    const response = await fetch(versionUrl, {
-      cache: 'no-store',
-      headers: {
-        'cache-control': 'no-cache',
-        'pragma': 'no-cache',
-      },
-    });
-
-    if (!response.ok) {
-      return;
-    }
-
-    const manifest = await response.json() as { version?: string };
-    if (!manifest.version || manifest.version === CURRENT_DEPLOY_VERSION) {
-      return;
-    }
-
-    if (!('serviceWorker' in navigator)) {
-      window.location.reload();
-      return;
-    }
-
-    const registration = await navigator.serviceWorker.getRegistration(import.meta.env.BASE_URL);
-    if (!registration) {
-      window.location.reload();
-      return;
-    }
-
-    await registration.update();
-  }
-  catch {
-    // Keep the current app usable if the version endpoint is temporarily unavailable.
-  }
-  finally {
-    versionCheckRunning = false;
-  }
-}
+const checkDeployVersion = createDeployVersionChecker({
+  currentVersion: import.meta.env.VITE_DEPLOY_VERSION,
+  versionManifestUrl: `${import.meta.env.BASE_URL}version.json`,
+  origin: window.location.origin,
+  baseUrl: import.meta.env.BASE_URL,
+  isOnline: () => navigator.onLine,
+  fetchVersion: (url, init) => fetch(url, init),
+  hasServiceWorker: () => 'serviceWorker' in navigator,
+  getRegistration: scope => navigator.serviceWorker.getRegistration(scope),
+  reload: () => window.location.reload(),
+});
 
 void checkDeployVersion();
 window.addEventListener('pageshow', () => {

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -17,12 +17,12 @@ function createChecker({
   registrationExists = true,
   responseOk = true,
 }: {
-  currentVersion?: string,
-  serverVersion?: string,
-  online?: boolean,
-  serviceWorkerSupported?: boolean,
-  registrationExists?: boolean,
-  responseOk?: boolean,
+  currentVersion?: string
+  serverVersion?: string
+  online?: boolean
+  serviceWorkerSupported?: boolean
+  registrationExists?: boolean
+  responseOk?: boolean
 } = {}) {
   const update = vi.fn().mockResolvedValue(undefined);
   const reload = vi.fn();

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -17,12 +17,12 @@ function createChecker({
   registrationExists = true,
   responseOk = true,
 }: {
-  currentVersion?: string;
-  serverVersion?: string;
-  online?: boolean;
-  serviceWorkerSupported?: boolean;
-  registrationExists?: boolean;
-  responseOk?: boolean;
+  currentVersion?: string,
+  serverVersion?: string,
+  online?: boolean,
+  serviceWorkerSupported?: boolean,
+  registrationExists?: boolean,
+  responseOk?: boolean,
 } = {}) {
   const update = vi.fn().mockResolvedValue(undefined);
   const reload = vi.fn();

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createDeployVersionChecker } from './deploy-version';
+
+function createResponse(version?: string, ok = true) {
+  return {
+    ok,
+    json: vi.fn().mockResolvedValue(version === undefined ? {} : { version }),
+  };
+}
+
+function createChecker({
+  currentVersion = 'deploy-v2',
+  serverVersion = 'deploy-v2',
+  online = true,
+  serviceWorkerSupported = true,
+  registrationExists = true,
+  responseOk = true,
+}: {
+  currentVersion?: string;
+  serverVersion?: string;
+  online?: boolean;
+  serviceWorkerSupported?: boolean;
+  registrationExists?: boolean;
+  responseOk?: boolean;
+} = {}) {
+  const update = vi.fn().mockResolvedValue(undefined);
+  const reload = vi.fn();
+  const fetchVersion = vi.fn().mockResolvedValue(createResponse(serverVersion, responseOk));
+  const getRegistration = vi.fn().mockResolvedValue(registrationExists ? { update } : undefined);
+
+  const checkDeployVersion = createDeployVersionChecker({
+    currentVersion,
+    versionManifestUrl: '/version.json',
+    origin: 'https://tools.eplus.dev',
+    baseUrl: '/',
+    isOnline: () => online,
+    fetchVersion,
+    hasServiceWorker: () => serviceWorkerSupported,
+    getRegistration,
+    reload,
+    now: () => 1234567890,
+  });
+
+  return {
+    checkDeployVersion,
+    fetchVersion,
+    getRegistration,
+    update,
+    reload,
+  };
+}
+
+describe('deploy version checker', () => {
+  it('updates a legacy visitor that has no embedded deploy version', async () => {
+    const { checkDeployVersion, update, reload } = createChecker({
+      currentVersion: undefined,
+      serverVersion: 'deploy-v2',
+    });
+
+    await checkDeployVersion();
+
+    expect(update).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads a legacy visitor without a service worker registration', async () => {
+    const { checkDeployVersion, update, reload } = createChecker({
+      currentVersion: undefined,
+      serverVersion: 'deploy-v2',
+      registrationExists: false,
+    });
+
+    await checkDeployVersion();
+
+    expect(update).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing for a new visitor already running the latest deploy', async () => {
+    const { checkDeployVersion, getRegistration, update, reload } = createChecker({
+      currentVersion: 'deploy-v2',
+      serverVersion: 'deploy-v2',
+    });
+
+    await checkDeployVersion();
+
+    expect(getRegistration).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('updates a returning visitor when the server has a newer deploy', async () => {
+    const { checkDeployVersion, update, reload } = createChecker({
+      currentVersion: 'deploy-v1',
+      serverVersion: 'deploy-v2',
+    });
+
+    await checkDeployVersion();
+
+    expect(update).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads on a version mismatch when service workers are unsupported', async () => {
+    const { checkDeployVersion, getRegistration, update, reload } = createChecker({
+      currentVersion: 'deploy-v1',
+      serverVersion: 'deploy-v2',
+      serviceWorkerSupported: false,
+    });
+
+    await checkDeployVersion();
+
+    expect(getRegistration).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a manifest that does not contain a valid version', async () => {
+    const { checkDeployVersion, getRegistration, update, reload } = createChecker({
+      currentVersion: 'deploy-v1',
+      serverVersion: undefined,
+    });
+
+    await checkDeployVersion();
+
+    expect(getRegistration).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch the version manifest while offline', async () => {
+    const { checkDeployVersion, fetchVersion, update, reload } = createChecker({
+      online: false,
+    });
+
+    await checkDeployVersion();
+
+    expect(fetchVersion).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('ignores a failed version manifest response', async () => {
+    const { checkDeployVersion, getRegistration, update, reload } = createChecker({
+      currentVersion: 'deploy-v1',
+      serverVersion: 'deploy-v2',
+      responseOk: false,
+    });
+
+    await checkDeployVersion();
+
+    expect(getRegistration).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('uses a cache-busting version request', async () => {
+    const { checkDeployVersion, fetchVersion } = createChecker();
+
+    await checkDeployVersion();
+
+    expect(fetchVersion).toHaveBeenCalledOnce();
+    const [url, init] = fetchVersion.mock.calls[0];
+    expect(url.toString()).toBe('https://tools.eplus.dev/version.json?_=1234567890');
+    expect(init).toMatchObject({
+      cache: 'no-store',
+      headers: {
+        'cache-control': 'no-cache',
+        'pragma': 'no-cache',
+      },
+    });
+  });
+
+  it('deduplicates overlapping version checks', async () => {
+    let resolveResponse!: (value: ReturnType<typeof createResponse>) => void;
+    const pendingResponse = new Promise<ReturnType<typeof createResponse>>((resolve) => {
+      resolveResponse = resolve;
+    });
+    const fetchVersion = vi.fn().mockReturnValue(pendingResponse);
+    const update = vi.fn().mockResolvedValue(undefined);
+
+    const checkDeployVersion = createDeployVersionChecker({
+      currentVersion: 'deploy-v1',
+      versionManifestUrl: '/version.json',
+      origin: 'https://tools.eplus.dev',
+      baseUrl: '/',
+      isOnline: () => true,
+      fetchVersion,
+      hasServiceWorker: () => true,
+      getRegistration: vi.fn().mockResolvedValue({ update }),
+      reload: vi.fn(),
+      now: () => 1234567890,
+    });
+
+    const firstCheck = checkDeployVersion();
+    const secondCheck = checkDeployVersion();
+    resolveResponse(createResponse('deploy-v2'));
+    await Promise.all([firstCheck, secondCheck]);
+
+    expect(fetchVersion).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalledOnce();
+  });
+});

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -9,14 +9,7 @@ function createResponse(version?: string, ok = true) {
   };
 }
 
-function createChecker({
-  currentVersion = 'deploy-v2',
-  serverVersion = 'deploy-v2',
-  online = true,
-  serviceWorkerSupported = true,
-  registrationExists = true,
-  responseOk = true,
-}: {
+function createChecker(options: {
   currentVersion?: string
   serverVersion?: string
   online?: boolean
@@ -24,6 +17,13 @@ function createChecker({
   registrationExists?: boolean
   responseOk?: boolean
 } = {}) {
+  const currentVersion = 'currentVersion' in options ? options.currentVersion : 'deploy-v2';
+  const serverVersion = 'serverVersion' in options ? options.serverVersion : 'deploy-v2';
+  const online = options.online ?? true;
+  const serviceWorkerSupported = options.serviceWorkerSupported ?? true;
+  const registrationExists = options.registrationExists ?? true;
+  const responseOk = options.responseOk ?? true;
+
   const update = vi.fn().mockResolvedValue(undefined);
   const reload = vi.fn();
   const fetchVersion = vi.fn().mockResolvedValue(createResponse(serverVersion, responseOk));

--- a/src/modules/app-version/deploy-version.ts
+++ b/src/modules/app-version/deploy-version.ts
@@ -1,23 +1,23 @@
 export interface VersionManifestResponse {
-  ok: boolean;
-  json: () => Promise<unknown>;
+  ok: boolean,
+  json: () => Promise<unknown>,
 }
 
 export interface ServiceWorkerRegistrationLike {
-  update: () => Promise<unknown>;
+  update: () => Promise<unknown>,
 }
 
 export interface DeployVersionCheckerOptions {
-  currentVersion?: string;
-  versionManifestUrl: string;
-  origin: string;
-  baseUrl: string;
-  isOnline: () => boolean;
-  fetchVersion: (url: URL, init: RequestInit) => Promise<VersionManifestResponse>;
-  hasServiceWorker: () => boolean;
-  getRegistration: (scope: string) => Promise<ServiceWorkerRegistrationLike | undefined>;
-  reload: () => void;
-  now?: () => number;
+  currentVersion?: string,
+  versionManifestUrl: string,
+  origin: string,
+  baseUrl: string,
+  isOnline: () => boolean,
+  fetchVersion: (url: URL, init: RequestInit) => Promise<VersionManifestResponse>,
+  hasServiceWorker: () => boolean,
+  getRegistration: (scope: string) => Promise<ServiceWorkerRegistrationLike | undefined>,
+  reload: () => void,
+  now?: () => number,
 }
 
 function getManifestVersion(manifest: unknown) {

--- a/src/modules/app-version/deploy-version.ts
+++ b/src/modules/app-version/deploy-version.ts
@@ -1,23 +1,23 @@
 export interface VersionManifestResponse {
-  ok: boolean,
-  json: () => Promise<unknown>,
+  ok: boolean
+  json: () => Promise<unknown>
 }
 
 export interface ServiceWorkerRegistrationLike {
-  update: () => Promise<unknown>,
+  update: () => Promise<unknown>
 }
 
 export interface DeployVersionCheckerOptions {
-  currentVersion?: string,
-  versionManifestUrl: string,
-  origin: string,
-  baseUrl: string,
-  isOnline: () => boolean,
-  fetchVersion: (url: URL, init: RequestInit) => Promise<VersionManifestResponse>,
-  hasServiceWorker: () => boolean,
-  getRegistration: (scope: string) => Promise<ServiceWorkerRegistrationLike | undefined>,
-  reload: () => void,
-  now?: () => number,
+  currentVersion?: string
+  versionManifestUrl: string
+  origin: string
+  baseUrl: string
+  isOnline: () => boolean
+  fetchVersion: (url: URL, init: RequestInit) => Promise<VersionManifestResponse>
+  hasServiceWorker: () => boolean
+  getRegistration: (scope: string) => Promise<ServiceWorkerRegistrationLike | undefined>
+  reload: () => void
+  now?: () => number
 }
 
 function getManifestVersion(manifest: unknown) {

--- a/src/modules/app-version/deploy-version.ts
+++ b/src/modules/app-version/deploy-version.ts
@@ -1,0 +1,96 @@
+export interface VersionManifestResponse {
+  ok: boolean;
+  json: () => Promise<unknown>;
+}
+
+export interface ServiceWorkerRegistrationLike {
+  update: () => Promise<unknown>;
+}
+
+export interface DeployVersionCheckerOptions {
+  currentVersion?: string;
+  versionManifestUrl: string;
+  origin: string;
+  baseUrl: string;
+  isOnline: () => boolean;
+  fetchVersion: (url: URL, init: RequestInit) => Promise<VersionManifestResponse>;
+  hasServiceWorker: () => boolean;
+  getRegistration: (scope: string) => Promise<ServiceWorkerRegistrationLike | undefined>;
+  reload: () => void;
+  now?: () => number;
+}
+
+function getManifestVersion(manifest: unknown) {
+  if (!manifest || typeof manifest !== 'object') {
+    return undefined;
+  }
+
+  const { version } = manifest as { version?: unknown };
+  return typeof version === 'string' && version.length > 0 ? version : undefined;
+}
+
+export function createDeployVersionChecker({
+  currentVersion,
+  versionManifestUrl,
+  origin,
+  baseUrl,
+  isOnline,
+  fetchVersion,
+  hasServiceWorker,
+  getRegistration,
+  reload,
+  now = Date.now,
+}: DeployVersionCheckerOptions) {
+  let versionCheckRunning = false;
+
+  return async function checkDeployVersion() {
+    if (versionCheckRunning || !isOnline()) {
+      return;
+    }
+
+    versionCheckRunning = true;
+
+    try {
+      const versionUrl = new URL(versionManifestUrl, origin);
+      versionUrl.searchParams.set('_', now().toString());
+
+      const response = await fetchVersion(versionUrl, {
+        cache: 'no-store',
+        headers: {
+          'cache-control': 'no-cache',
+          'pragma': 'no-cache',
+        },
+      });
+
+      if (!response.ok) {
+        return;
+      }
+
+      const serverVersion = getManifestVersion(await response.json());
+      if (!serverVersion || serverVersion === currentVersion) {
+        return;
+      }
+
+      // A legacy visitor may have no deploy version embedded in the running bundle.
+      // Any valid server version is therefore considered newer and triggers recovery.
+      if (!hasServiceWorker()) {
+        reload();
+        return;
+      }
+
+      const registration = await getRegistration(baseUrl);
+      if (!registration) {
+        reload();
+        return;
+      }
+
+      await registration.update();
+    }
+    catch {
+      // Keep the current app usable if the version endpoint is temporarily unavailable.
+    }
+    finally {
+      versionCheckRunning = false;
+    }
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,11 @@ import svgLoader from 'vite-svg-loader';
 import { configDefaults } from 'vitest/config';
 
 const baseUrl = process.env.BASE_URL ?? '/';
+const deployVersion = process.env.DEPLOY_ID
+  ?? process.env.BUILD_ID
+  ?? process.env.COMMIT_REF
+  ?? `local-${Date.now()}`;
+const deployBuiltAt = new Date().toISOString();
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -53,9 +58,27 @@ export default defineConfig({
     vueJsx(),
     markdown(),
     svgLoader(),
+    {
+      name: 'eplus-deploy-version',
+      generateBundle() {
+        this.emitFile({
+          type: 'asset',
+          fileName: 'version.json',
+          source: `${JSON.stringify({
+            version: deployVersion,
+            commit: process.env.COMMIT_REF ?? null,
+            context: process.env.CONTEXT ?? null,
+            builtAt: deployBuiltAt,
+          }, null, 2)}\n`,
+        });
+      },
+    },
     VitePWA({
       registerType: 'autoUpdate',
       strategies: 'generateSW',
+      workbox: {
+        globIgnores: ['**/version.json'],
+      },
       manifest: {
         name: 'ePlus.DEV IT Tools',
         short_name: 'ePlus Tools',
@@ -134,6 +157,7 @@ export default defineConfig({
   },
   define: {
     'import.meta.env.PACKAGE_VERSION': JSON.stringify(process.env.npm_package_version),
+    'import.meta.env.VITE_DEPLOY_VERSION': JSON.stringify(deployVersion),
   },
   test: {
     exclude: [...configDefaults.exclude, '**/*.e2e.spec.ts'],


### PR DESCRIPTION
## What changed
- generate a unique `version.json` for every Netlify deploy using `DEPLOY_ID` (with build/commit fallbacks)
- embed the same deploy version into the Vite bundle
- when a visitor opens/restores the page, fetch `version.json` with `no-store` and compare it with the running bundle
- if the versions differ, explicitly trigger the service-worker registration update
- exclude `version.json` from the Workbox precache and mark it `no-store` on Netlify
- remove the previous 15-minute polling behavior; the version check is now entry-driven

## Why
This makes deploy freshness deterministic instead of relying only on the browser's service-worker update timing. Each deploy has its own version ID. A returning visitor checks the server version immediately, and a mismatch forces the PWA update path without asking the user to clear cache/cookies or open incognito mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment version tracking to improve update detection.
  * The app now checks for updates at startup and when returning to a page.
  * Automatically refreshes or updates the service worker when a newer deployment is available.

* **Bug Fixes**
  * Prevented cached version information from delaying detection of new releases.
  * Added fallback behavior for environments without service-worker support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->