### PR TITLE
fix: refresh stale menu and search after deploy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import { installGoogleAnalytics } from './plugins/google-analytics.plugin';
 import { i18nPlugin } from './plugins/i18n.plugin';
 import { createDeployVersionChecker } from './modules/app-version/deploy-version';
 
-registerSW({ immediate: true });
+const updateSW = registerSW({ immediate: true });
 
 const checkDeployVersion = createDeployVersionChecker({
   currentVersion: import.meta.env.VITE_DEPLOY_VERSION,
@@ -26,6 +26,7 @@ const checkDeployVersion = createDeployVersionChecker({
   fetchVersion: (url, init) => fetch(url, init),
   hasServiceWorker: () => 'serviceWorker' in navigator,
   getRegistration: scope => navigator.serviceWorker.getRegistration(scope),
+  updateServiceWorker: () => updateSW(true),
   reload: () => window.location.reload(),
 });
 

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -25,6 +25,7 @@ function createChecker(options: {
   const responseOk = options.responseOk ?? true;
 
   const update = vi.fn().mockResolvedValue(undefined);
+  const updateServiceWorker = vi.fn().mockResolvedValue(undefined);
   const reload = vi.fn();
   const fetchVersion = vi.fn().mockResolvedValue(createResponse(serverVersion, responseOk));
   const getRegistration = vi.fn().mockResolvedValue(registrationExists ? { update } : undefined);
@@ -38,6 +39,7 @@ function createChecker(options: {
     fetchVersion,
     hasServiceWorker: () => serviceWorkerSupported,
     getRegistration,
+    updateServiceWorker,
     reload,
     now: () => 1234567890,
   });
@@ -47,25 +49,26 @@ function createChecker(options: {
     fetchVersion,
     getRegistration,
     update,
+    updateServiceWorker,
     reload,
   };
 }
 
 describe('deploy version checker', () => {
-  it('updates a legacy visitor that has no embedded deploy version', async () => {
-    const { checkDeployVersion, update, reload } = createChecker({
+  it('refreshes a legacy visitor that has no embedded deploy version', async () => {
+    const { checkDeployVersion, updateServiceWorker, reload } = createChecker({
       currentVersion: undefined,
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(update).toHaveBeenCalledOnce();
+    expect(updateServiceWorker).toHaveBeenCalledOnce();
     expect(reload).not.toHaveBeenCalled();
   });
 
   it('reloads a legacy visitor without a service worker registration', async () => {
-    const { checkDeployVersion, update, reload } = createChecker({
+    const { checkDeployVersion, updateServiceWorker, reload } = createChecker({
       currentVersion: undefined,
       serverVersion: 'deploy-v2',
       registrationExists: false,
@@ -73,12 +76,12 @@ describe('deploy version checker', () => {
 
     await checkDeployVersion();
 
-    expect(update).not.toHaveBeenCalled();
+    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).toHaveBeenCalledOnce();
   });
 
   it('does nothing for a new visitor already running the latest deploy', async () => {
-    const { checkDeployVersion, getRegistration, update, reload } = createChecker({
+    const { checkDeployVersion, getRegistration, updateServiceWorker, reload } = createChecker({
       currentVersion: 'deploy-v2',
       serverVersion: 'deploy-v2',
     });
@@ -86,24 +89,24 @@ describe('deploy version checker', () => {
     await checkDeployVersion();
 
     expect(getRegistration).not.toHaveBeenCalled();
-    expect(update).not.toHaveBeenCalled();
+    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it('updates a returning visitor when the server has a newer deploy', async () => {
-    const { checkDeployVersion, update, reload } = createChecker({
+  it('refreshes a returning visitor when the server has a newer deploy', async () => {
+    const { checkDeployVersion, updateServiceWorker, reload } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(update).toHaveBeenCalledOnce();
+    expect(updateServiceWorker).toHaveBeenCalledOnce();
     expect(reload).not.toHaveBeenCalled();
   });
 
   it('reloads on a version mismatch when service workers are unsupported', async () => {
-    const { checkDeployVersion, getRegistration, update, reload } = createChecker({
+    const { checkDeployVersion, getRegistration, updateServiceWorker, reload } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: 'deploy-v2',
       serviceWorkerSupported: false,
@@ -112,12 +115,12 @@ describe('deploy version checker', () => {
     await checkDeployVersion();
 
     expect(getRegistration).not.toHaveBeenCalled();
-    expect(update).not.toHaveBeenCalled();
+    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).toHaveBeenCalledOnce();
   });
 
   it('ignores a manifest that does not contain a valid version', async () => {
-    const { checkDeployVersion, getRegistration, update, reload } = createChecker({
+    const { checkDeployVersion, getRegistration, updateServiceWorker, reload } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: undefined,
     });
@@ -125,24 +128,24 @@ describe('deploy version checker', () => {
     await checkDeployVersion();
 
     expect(getRegistration).not.toHaveBeenCalled();
-    expect(update).not.toHaveBeenCalled();
+    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
 
   it('does not fetch the version manifest while offline', async () => {
-    const { checkDeployVersion, fetchVersion, update, reload } = createChecker({
+    const { checkDeployVersion, fetchVersion, updateServiceWorker, reload } = createChecker({
       online: false,
     });
 
     await checkDeployVersion();
 
     expect(fetchVersion).not.toHaveBeenCalled();
-    expect(update).not.toHaveBeenCalled();
+    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
 
   it('ignores a failed version manifest response', async () => {
-    const { checkDeployVersion, getRegistration, update, reload } = createChecker({
+    const { checkDeployVersion, getRegistration, updateServiceWorker, reload } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: 'deploy-v2',
       responseOk: false,
@@ -151,7 +154,7 @@ describe('deploy version checker', () => {
     await checkDeployVersion();
 
     expect(getRegistration).not.toHaveBeenCalled();
-    expect(update).not.toHaveBeenCalled();
+    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
 
@@ -178,7 +181,7 @@ describe('deploy version checker', () => {
       resolveResponse = resolve;
     });
     const fetchVersion = vi.fn().mockReturnValue(pendingResponse);
-    const update = vi.fn().mockResolvedValue(undefined);
+    const updateServiceWorker = vi.fn().mockResolvedValue(undefined);
 
     const checkDeployVersion = createDeployVersionChecker({
       currentVersion: 'deploy-v1',
@@ -188,7 +191,8 @@ describe('deploy version checker', () => {
       isOnline: () => true,
       fetchVersion,
       hasServiceWorker: () => true,
-      getRegistration: vi.fn().mockResolvedValue({ update }),
+      getRegistration: vi.fn().mockResolvedValue({ update: vi.fn().mockResolvedValue(undefined) }),
+      updateServiceWorker,
       reload: vi.fn(),
       now: () => 1234567890,
     });
@@ -199,6 +203,6 @@ describe('deploy version checker', () => {
     await Promise.all([firstCheck, secondCheck]);
 
     expect(fetchVersion).toHaveBeenCalledOnce();
-    expect(update).toHaveBeenCalledOnce();
+    expect(updateServiceWorker).toHaveBeenCalledOnce();
   });
 });

--- a/src/modules/app-version/deploy-version.ts
+++ b/src/modules/app-version/deploy-version.ts
@@ -16,6 +16,7 @@ export interface DeployVersionCheckerOptions {
   fetchVersion: (url: URL, init: RequestInit) => Promise<VersionManifestResponse>
   hasServiceWorker: () => boolean
   getRegistration: (scope: string) => Promise<ServiceWorkerRegistrationLike | undefined>
+  updateServiceWorker: () => Promise<void>
   reload: () => void
   now?: () => number
 }
@@ -38,6 +39,7 @@ export function createDeployVersionChecker({
   fetchVersion,
   hasServiceWorker,
   getRegistration,
+  updateServiceWorker,
   reload,
   now = Date.now,
 }: DeployVersionCheckerOptions) {
@@ -84,7 +86,7 @@ export function createDeployVersionChecker({
         return;
       }
 
-      await registration.update();
+      await updateServiceWorker();
     }
     catch {
       // Keep the current app usable if the version endpoint is temporarily unavailable.

--- a/src/tools/vietqr-discovery.test.ts
+++ b/src/tools/vietqr-discovery.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { toolsWithCategory } from './index';
+
+describe('VietQR tool discovery', () => {
+  it('keeps VietQR registered in the menu registry with searchable keywords', () => {
+    const vietQrTool = toolsWithCategory.find(tool => tool.path === '/vietqr-bank-generator');
+
+    expect(vietQrTool).toBeDefined();
+    expect(vietQrTool?.category).toBe('Vietnam');
+    expect(vietQrTool?.keywords).toContain('vietqr');
+    expect(vietQrTool?.keywords).toContain('bank');
+  });
+});


### PR DESCRIPTION
## What changed
- use the updater returned by `virtual:pwa-register` with `reloadPage=true` when `version.json` differs from the running bundle
- keep reload fallbacks for browsers without Service Worker support or without a registration
- extend deploy-version unit tests for legacy users, first-time users, returning users and forced refresh behavior
- add a regression test that keeps `/vietqr-bank-generator` registered under the Vietnam category with `vietqr`/`bank` search keywords

## Why
VietQR is already registered in the shared tool registry, and both the side menu and command palette are built from that registry. If both are missing while the direct tool route exists, the browser is still displaying an older cached application shell. The previous version checker called `registration.update()` but did not explicitly request the current page to reload through vite-plugin-pwa's updater. This follow-up makes the refresh deterministic after a deploy mismatch.