### PR TITLE
fix: retire stale PWA cache on legacy clients

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -4,6 +4,8 @@
 interface ImportMetaEnv {
   VITE_GOOGLE_ANALYTICS_ENABLED?: string;
   VITE_GOOGLE_ANALYTICS_ID?: string;
+  VITE_DEPLOY_VERSION: string;
+  VITE_DEPLOY_COMMIT: string;
   PACKAGE_VERSION: string;
   GIT_SHORT_SHA: string;
   PROD: boolean;

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,28 @@
+/*
+ * Legacy Workbox cleanup worker.
+ *
+ * Keep this file at /sw.js permanently: older visitors may still have a
+ * registration pointing to this exact URL. When their browser checks for a
+ * Service Worker update, this worker replaces the old precaching worker,
+ * unregisters itself, deletes stale Cache Storage entries and reloads open
+ * tabs so the current no-store HTML and content-hashed assets are used.
+ */
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    await self.registration.unregister();
+
+    const cacheNames = await caches.keys();
+    await Promise.all(cacheNames.map(cacheName => caches.delete(cacheName)));
+
+    const clients = await self.clients.matchAll({
+      type: 'window',
+      includeUncontrolled: true,
+    });
+
+    await Promise.all(clients.map(client => client.navigate(client.url)));
+  })());
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,16 +3,22 @@ import { figue } from 'figue';
 export const config = figue({
   app: {
     version: {
-      doc: 'Application current version',
+      doc: 'Application package version',
       format: 'string',
       default: '0.0.0',
       env: 'PACKAGE_VERSION',
     },
+    deployVersion: {
+      doc: 'Unique deployment version for the running build',
+      format: 'string',
+      default: 'local',
+      env: 'VITE_DEPLOY_VERSION',
+    },
     lastCommitSha: {
-      doc: 'Application last commit SHA version',
+      doc: 'Git commit SHA for the running deployment',
       format: 'string',
       default: '',
-      env: 'VITE_VERCEL_GIT_COMMIT_SHA',
+      env: 'VITE_DEPLOY_COMMIT',
     },
     baseUrl: {
       doc: 'Application base url',
@@ -57,8 +63,10 @@ export const config = figue({
 })
   .loadEnv({
     ...import.meta.env,
-    // Because the string 'import.meta.env.PACKAGE_VERSION' is statically replaced during build time (see 'define' in vite.config.ts)
+    // These values are statically replaced at build time (see `define` in vite.config.ts).
     PACKAGE_VERSION: import.meta.env.PACKAGE_VERSION,
+    VITE_DEPLOY_VERSION: import.meta.env.VITE_DEPLOY_VERSION,
+    VITE_DEPLOY_COMMIT: import.meta.env.VITE_DEPLOY_COMMIT,
   })
   .validate()
   .getConfig();

--- a/src/layouts/base.layout.vue
+++ b/src/layouts/base.layout.vue
@@ -66,7 +66,7 @@ const tools = computed<ToolCategory[]>(() => [
         <CollapsibleToolMenu :tools-by-category="tools" />
 
         <div class="footer">
-          <div class="build-meta">
+          <div class="build-meta" data-testid="deploy-build-meta">
             <span>ePlus.DEV Tools</span>
             <span class="build-chip" :title="deployVersion">Build {{ deployLabel }}</span>
 

--- a/src/layouts/base.layout.vue
+++ b/src/layouts/base.layout.vue
@@ -18,10 +18,12 @@ import CollapsibleToolMenu from '@/components/CollapsibleToolMenu.vue';
 
 const themeVars = useThemeVars();
 const styleStore = useStyleStore();
-const deployVersion = import.meta.env.VITE_DEPLOY_VERSION;
-const deployCommitFull = import.meta.env.VITE_DEPLOY_COMMIT;
+const deployVersion = config.app.deployVersion;
+const deployCommitFull = config.app.lastCommitSha;
 const deployCommit = deployCommitFull.slice(0, 7);
-const deployLabel = deployVersion.startsWith('local-') ? 'local' : deployVersion.slice(0, 8);
+const deployLabel = deployVersion.startsWith('local-') || deployVersion === 'local'
+  ? 'local'
+  : deployVersion.slice(0, 8);
 
 const { tracker } = useTracker();
 const { t } = useI18n();

--- a/src/layouts/base.layout.vue
+++ b/src/layouts/base.layout.vue
@@ -19,7 +19,8 @@ import CollapsibleToolMenu from '@/components/CollapsibleToolMenu.vue';
 const themeVars = useThemeVars();
 const styleStore = useStyleStore();
 const deployVersion = import.meta.env.VITE_DEPLOY_VERSION;
-const deployCommit = import.meta.env.VITE_DEPLOY_COMMIT.slice(0, 7);
+const deployCommitFull = import.meta.env.VITE_DEPLOY_COMMIT;
+const deployCommit = deployCommitFull.slice(0, 7);
 const deployLabel = deployVersion.startsWith('local-') ? 'local' : deployVersion.slice(0, 8);
 
 const { tracker } = useTracker();
@@ -75,8 +76,8 @@ const tools = computed<ToolCategory[]>(() => [
                 target="_blank"
                 rel="noopener"
                 type="primary"
-                :href="`https://github.com/hoangsvit/it-tools/commit/${deployCommit}`"
-                :title="`Git commit ${deployCommit}`"
+                :href="`https://github.com/hoangsvit/it-tools/commit/${deployCommitFull}`"
+                :title="`Git commit ${deployCommitFull}`"
               >
                 {{ deployCommit }}
               </c-link>

--- a/src/layouts/base.layout.vue
+++ b/src/layouts/base.layout.vue
@@ -18,8 +18,9 @@ import CollapsibleToolMenu from '@/components/CollapsibleToolMenu.vue';
 
 const themeVars = useThemeVars();
 const styleStore = useStyleStore();
-const version = config.app.version;
-const commitSha = config.app.lastCommitSha.slice(0, 7);
+const deployVersion = import.meta.env.VITE_DEPLOY_VERSION;
+const deployCommit = import.meta.env.VITE_DEPLOY_COMMIT.slice(0, 7);
+const deployLabel = deployVersion.startsWith('local-') ? 'local' : deployVersion.slice(0, 8);
 
 const { tracker } = useTracker();
 const { t } = useI18n();
@@ -64,22 +65,20 @@ const tools = computed<ToolCategory[]>(() => [
         <CollapsibleToolMenu :tools-by-category="tools" />
 
         <div class="footer">
-          <div>
-            IT-Tools
+          <div class="build-meta">
+            <span>ePlus.DEV Tools</span>
+            <span class="build-chip" :title="deployVersion">Build {{ deployLabel }}</span>
 
-            <c-link target="_blank" rel="noopener" :href="`https://github.com/hoangsvit/it-tools/tree/v${version}`">
-              v{{ version }}
-            </c-link>
-
-            <template v-if="commitSha && commitSha.length > 0">
-              -
+            <template v-if="deployCommit">
+              <span aria-hidden="true">·</span>
               <c-link
                 target="_blank"
                 rel="noopener"
                 type="primary"
-                :href="`https://github.com/hoangsvit/it-tools/tree/${commitSha}`"
+                :href="`https://github.com/hoangsvit/it-tools/commit/${deployCommit}`"
+                :title="`Git commit ${deployCommit}`"
               >
-                {{ commitSha }}
+                {{ deployCommit }}
               </c-link>
             </template>
           </div>
@@ -169,6 +168,28 @@ const tools = computed<ToolCategory[]>(() => [
   color: #838587;
   margin-top: 20px;
   padding: 20px 0;
+}
+
+.build-meta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 3px;
+}
+
+.build-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 1px 7px;
+  border: 1px solid rgba(24, 160, 88, 0.25);
+  border-radius: 999px;
+  color: #18a058;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
 .upstream-credit {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import { createHead } from '@vueuse/head';
 
-import { registerSW } from 'virtual:pwa-register';
 import shadow from 'vue-shadow-dom';
 
 import 'virtual:uno.css';
@@ -15,18 +14,12 @@ import { installGoogleAnalytics } from './plugins/google-analytics.plugin';
 import { i18nPlugin } from './plugins/i18n.plugin';
 import { createDeployVersionChecker } from './modules/app-version/deploy-version';
 
-const updateSW = registerSW({ immediate: true });
-
 const checkDeployVersion = createDeployVersionChecker({
   currentVersion: import.meta.env.VITE_DEPLOY_VERSION,
   versionManifestUrl: `${import.meta.env.BASE_URL}version.json`,
   origin: window.location.origin,
-  baseUrl: import.meta.env.BASE_URL,
   isOnline: () => navigator.onLine,
   fetchVersion: (url, init) => fetch(url, init),
-  hasServiceWorker: () => 'serviceWorker' in navigator,
-  getRegistration: scope => navigator.serviceWorker.getRegistration(scope),
-  updateServiceWorker: () => updateSW(true),
   reload: () => window.location.reload(),
 });
 

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -13,33 +13,22 @@ function createChecker(options: {
   currentVersion?: string
   serverVersion?: string
   online?: boolean
-  serviceWorkerSupported?: boolean
-  registrationExists?: boolean
   responseOk?: boolean
 } = {}) {
   const currentVersion = 'currentVersion' in options ? options.currentVersion : 'deploy-v2';
   const serverVersion = 'serverVersion' in options ? options.serverVersion : 'deploy-v2';
   const online = options.online ?? true;
-  const serviceWorkerSupported = options.serviceWorkerSupported ?? true;
-  const registrationExists = options.registrationExists ?? true;
   const responseOk = options.responseOk ?? true;
 
-  const update = vi.fn().mockResolvedValue(undefined);
-  const updateServiceWorker = vi.fn().mockResolvedValue(undefined);
   const reload = vi.fn();
   const fetchVersion = vi.fn().mockResolvedValue(createResponse(serverVersion, responseOk));
-  const getRegistration = vi.fn().mockResolvedValue(registrationExists ? { update } : undefined);
 
   const checkDeployVersion = createDeployVersionChecker({
     currentVersion,
     versionManifestUrl: '/version.json',
     origin: 'https://tools.eplus.dev',
-    baseUrl: '/',
     isOnline: () => online,
     fetchVersion,
-    hasServiceWorker: () => serviceWorkerSupported,
-    getRegistration,
-    updateServiceWorker,
     reload,
     now: () => 1234567890,
   });
@@ -47,105 +36,68 @@ function createChecker(options: {
   return {
     checkDeployVersion,
     fetchVersion,
-    getRegistration,
-    update,
-    updateServiceWorker,
     reload,
   };
 }
 
 describe('deploy version checker', () => {
-  it('refreshes a legacy visitor that has no embedded deploy version', async () => {
-    const { checkDeployVersion, updateServiceWorker, reload } = createChecker({
+  it('reloads a legacy visitor that has no embedded deploy version', async () => {
+    const { checkDeployVersion, reload } = createChecker({
       currentVersion: undefined,
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(updateServiceWorker).toHaveBeenCalledOnce();
-    expect(reload).not.toHaveBeenCalled();
-  });
-
-  it('reloads a legacy visitor without a service worker registration', async () => {
-    const { checkDeployVersion, updateServiceWorker, reload } = createChecker({
-      currentVersion: undefined,
-      serverVersion: 'deploy-v2',
-      registrationExists: false,
-    });
-
-    await checkDeployVersion();
-
-    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).toHaveBeenCalledOnce();
   });
 
   it('does nothing for a new visitor already running the latest deploy', async () => {
-    const { checkDeployVersion, getRegistration, updateServiceWorker, reload } = createChecker({
+    const { checkDeployVersion, reload } = createChecker({
       currentVersion: 'deploy-v2',
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(getRegistration).not.toHaveBeenCalled();
-    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it('refreshes a returning visitor when the server has a newer deploy', async () => {
-    const { checkDeployVersion, updateServiceWorker, reload } = createChecker({
+  it('reloads a returning visitor when the server has a newer deploy', async () => {
+    const { checkDeployVersion, reload } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(updateServiceWorker).toHaveBeenCalledOnce();
-    expect(reload).not.toHaveBeenCalled();
-  });
-
-  it('reloads on a version mismatch when service workers are unsupported', async () => {
-    const { checkDeployVersion, getRegistration, updateServiceWorker, reload } = createChecker({
-      currentVersion: 'deploy-v1',
-      serverVersion: 'deploy-v2',
-      serviceWorkerSupported: false,
-    });
-
-    await checkDeployVersion();
-
-    expect(getRegistration).not.toHaveBeenCalled();
-    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).toHaveBeenCalledOnce();
   });
 
   it('ignores a manifest that does not contain a valid version', async () => {
-    const { checkDeployVersion, getRegistration, updateServiceWorker, reload } = createChecker({
+    const { checkDeployVersion, reload } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: undefined,
     });
 
     await checkDeployVersion();
 
-    expect(getRegistration).not.toHaveBeenCalled();
-    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
 
   it('does not fetch the version manifest while offline', async () => {
-    const { checkDeployVersion, fetchVersion, updateServiceWorker, reload } = createChecker({
+    const { checkDeployVersion, fetchVersion, reload } = createChecker({
       online: false,
     });
 
     await checkDeployVersion();
 
     expect(fetchVersion).not.toHaveBeenCalled();
-    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
 
   it('ignores a failed version manifest response', async () => {
-    const { checkDeployVersion, getRegistration, updateServiceWorker, reload } = createChecker({
+    const { checkDeployVersion, reload } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: 'deploy-v2',
       responseOk: false,
@@ -153,8 +105,6 @@ describe('deploy version checker', () => {
 
     await checkDeployVersion();
 
-    expect(getRegistration).not.toHaveBeenCalled();
-    expect(updateServiceWorker).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
 
@@ -175,25 +125,21 @@ describe('deploy version checker', () => {
     });
   });
 
-  it('deduplicates overlapping version checks', async () => {
+  it('deduplicates overlapping version checks and reloads once', async () => {
     let resolveResponse!: (value: ReturnType<typeof createResponse>) => void;
     const pendingResponse = new Promise<ReturnType<typeof createResponse>>((resolve) => {
       resolveResponse = resolve;
     });
     const fetchVersion = vi.fn().mockReturnValue(pendingResponse);
-    const updateServiceWorker = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn();
 
     const checkDeployVersion = createDeployVersionChecker({
       currentVersion: 'deploy-v1',
       versionManifestUrl: '/version.json',
       origin: 'https://tools.eplus.dev',
-      baseUrl: '/',
       isOnline: () => true,
       fetchVersion,
-      hasServiceWorker: () => true,
-      getRegistration: vi.fn().mockResolvedValue({ update: vi.fn().mockResolvedValue(undefined) }),
-      updateServiceWorker,
-      reload: vi.fn(),
+      reload,
       now: () => 1234567890,
     });
 
@@ -203,6 +149,6 @@ describe('deploy version checker', () => {
     await Promise.all([firstCheck, secondCheck]);
 
     expect(fetchVersion).toHaveBeenCalledOnce();
-    expect(updateServiceWorker).toHaveBeenCalledOnce();
+    expect(reload).toHaveBeenCalledOnce();
   });
 });

--- a/src/modules/app-version/deploy-version.ts
+++ b/src/modules/app-version/deploy-version.ts
@@ -3,20 +3,12 @@ export interface VersionManifestResponse {
   json: () => Promise<unknown>
 }
 
-export interface ServiceWorkerRegistrationLike {
-  update: () => Promise<unknown>
-}
-
 export interface DeployVersionCheckerOptions {
   currentVersion?: string
   versionManifestUrl: string
   origin: string
-  baseUrl: string
   isOnline: () => boolean
   fetchVersion: (url: URL, init: RequestInit) => Promise<VersionManifestResponse>
-  hasServiceWorker: () => boolean
-  getRegistration: (scope: string) => Promise<ServiceWorkerRegistrationLike | undefined>
-  updateServiceWorker: () => Promise<void>
   reload: () => void
   now?: () => number
 }
@@ -34,12 +26,8 @@ export function createDeployVersionChecker({
   currentVersion,
   versionManifestUrl,
   origin,
-  baseUrl,
   isOnline,
   fetchVersion,
-  hasServiceWorker,
-  getRegistration,
-  updateServiceWorker,
   reload,
   now = Date.now,
 }: DeployVersionCheckerOptions) {
@@ -73,20 +61,10 @@ export function createDeployVersionChecker({
         return;
       }
 
-      // A legacy visitor may have no deploy version embedded in the running bundle.
-      // Any valid server version is therefore considered newer and triggers recovery.
-      if (!hasServiceWorker()) {
-        reload();
-        return;
-      }
-
-      const registration = await getRegistration(baseUrl);
-      if (!registration) {
-        reload();
-        return;
-      }
-
-      await updateServiceWorker();
+      // HTML is served with no-store and application assets are content-hashed.
+      // Reloading directly is therefore enough to move the browser to the new
+      // deploy without depending on Service Worker lifecycle timing.
+      reload();
     }
     catch {
       // Keep the current app usable if the version endpoint is temporarily unavailable.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ const deployVersion = process.env.DEPLOY_ID
   ?? process.env.BUILD_ID
   ?? process.env.COMMIT_REF
   ?? `local-${Date.now()}`;
+const deployCommit = process.env.COMMIT_REF ?? '';
 const deployBuiltAt = new Date().toISOString();
 
 // https://vitejs.dev/config/
@@ -66,7 +67,7 @@ export default defineConfig({
           fileName: 'version.json',
           source: `${JSON.stringify({
             version: deployVersion,
-            commit: process.env.COMMIT_REF ?? null,
+            commit: deployCommit || null,
             context: process.env.CONTEXT ?? null,
             builtAt: deployBuiltAt,
           }, null, 2)}\n`,
@@ -74,12 +75,11 @@ export default defineConfig({
       },
     },
     VitePWA({
-      // Keep generating the web-app manifest, but do not register a new caching
-      // service worker. public/sw.js is deliberately reserved as a legacy
-      // cleanup worker for visitors still controlled by an older Workbox build.
-      injectRegister: false,
-      filename: 'service-worker.js',
-      selfDestroying: true,
+      registerType: 'autoUpdate',
+      strategies: 'generateSW',
+      workbox: {
+        globIgnores: ['**/version.json'],
+      },
       manifest: {
         name: 'ePlus.DEV IT Tools',
         short_name: 'ePlus Tools',
@@ -159,6 +159,7 @@ export default defineConfig({
   define: {
     'import.meta.env.PACKAGE_VERSION': JSON.stringify(process.env.npm_package_version),
     'import.meta.env.VITE_DEPLOY_VERSION': JSON.stringify(deployVersion),
+    'import.meta.env.VITE_DEPLOY_COMMIT': JSON.stringify(deployCommit),
   },
   test: {
     exclude: [...configDefaults.exclude, '**/*.e2e.spec.ts'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,11 +74,12 @@ export default defineConfig({
       },
     },
     VitePWA({
-      registerType: 'autoUpdate',
-      strategies: 'generateSW',
-      workbox: {
-        globIgnores: ['**/version.json'],
-      },
+      // Keep generating the web-app manifest, but do not register a new caching
+      // service worker. public/sw.js is deliberately reserved as a legacy
+      // cleanup worker for visitors still controlled by an older Workbox build.
+      injectRegister: false,
+      filename: 'service-worker.js',
+      selfDestroying: true,
       manifest: {
         name: 'ePlus.DEV IT Tools',
         short_name: 'ePlus Tools',


### PR DESCRIPTION
## What changed
- stop registering the Workbox precaching service worker for new visitors
- keep the generated web-app manifest without letting it precache the app shell
- reserve `/sw.js` as a permanent legacy cleanup worker that unregisters old registrations, deletes Cache Storage and reloads controlled tabs
- make deploy freshness depend only on `version.json` + a normal page reload
- keep `index.html`/`version.json` no-store and Vite assets content-hashed
- simplify and update deploy-version unit tests for legacy, first-time, returning, offline and overlapping checks

## Why
The screenshot confirms an old iOS Safari client is still controlled by a previous Workbox app shell: the current repository already contains the VietQR tool in the shared registry, but the browser is rendering an older bundle where the Vietnam category is absent. Code inside the new bundle cannot repair a client that never loads that bundle. The legacy `/sw.js` cleanup worker fixes the migration at the Service Worker layer itself, then future deploys use `version.json` and normal HTTP caching instead of Cache Storage.