### PR TITLE
fix: preserve legacy cleanup service worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Build the app
         run: pnpm build
+
+      - name: Verify deploy freshness artifacts
+        run: node scripts/verify-production-artifacts.mjs

--- a/scripts/verify-production-artifacts.mjs
+++ b/scripts/verify-production-artifacts.mjs
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+
+async function readRequired(path) {
+  try {
+    return await readFile(path, 'utf8');
+  }
+  catch (error) {
+    throw new Error(`Missing required production artifact: ${path}`, { cause: error });
+  }
+}
+
+const [versionText, cleanupWorker, generatedWorker, indexHtml] = await Promise.all([
+  readRequired('dist/version.json'),
+  readRequired('dist/sw.js'),
+  readRequired('dist/service-worker.js'),
+  readRequired('dist/index.html'),
+]);
+
+const versionManifest = JSON.parse(versionText);
+if (typeof versionManifest.version !== 'string' || versionManifest.version.length === 0) {
+  throw new Error('dist/version.json must contain a non-empty version');
+}
+
+if (!cleanupWorker.includes('Legacy Workbox cleanup worker')
+  || !cleanupWorker.includes('self.registration.unregister()')) {
+  throw new Error('dist/sw.js was overwritten; it must remain the legacy cleanup worker');
+}
+
+if (!generatedWorker.includes('workbox')) {
+  throw new Error('dist/service-worker.js should contain the unregistered generated Workbox worker');
+}
+
+if (indexHtml.includes('registerSW.js') || indexHtml.includes('serviceWorker.register(')) {
+  throw new Error('New visitors must not auto-register a Workbox service worker');
+}
+
+console.log(`Production artifacts OK: deploy ${versionManifest.version}`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,7 +75,11 @@ export default defineConfig({
       },
     },
     VitePWA({
-      registerType: 'autoUpdate',
+      // Keep /sw.js free for the legacy cleanup worker in public/sw.js. The
+      // generated Workbox worker must use a different filename and must not be
+      // registered for new visitors while we retire the old app-shell cache.
+      filename: 'service-worker.js',
+      injectRegister: null,
       strategies: 'generateSW',
       workbox: {
         globIgnores: ['**/version.json'],


### PR DESCRIPTION
## Root cause
`public/sw.js` contains the intended legacy cleanup worker, but `vite-plugin-pwa` was still configured with `generateSW` using its default `sw.js` filename. During production build, the generated Workbox worker could replace the copied `public/sw.js`, so returning Safari users stayed on the stale app shell even though incognito users saw the latest bundle.

## Fix
- move the generated Workbox worker to `service-worker.js`
- set `injectRegister: null` so new visitors do not register it
- keep `/sw.js` exclusively for the legacy cleanup worker that unregisters old registrations, deletes Cache Storage and reloads controlled clients
- add a production-artifact verification script
- make CI fail if `dist/version.json` is missing, `dist/sw.js` is not the cleanup worker, or the app starts registering a Workbox worker again

This follows the vite-plugin-pwa documented migration pattern: keep the old service-worker filename for the cleanup worker and move any generated worker to another filename.