### PR TITLE
feat: show update countdown before deploy reload

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,12 +27,28 @@ const styleStore = useStyleStore();
 const theme = computed(() => (styleStore.isDarkTheme ? darkTheme : null));
 const themeOverrides = computed(() => (styleStore.isDarkTheme ? darkThemeOverrides : lightThemeOverrides));
 
-const { locale, t } = useI18n();
+const { locale } = useI18n();
 
 syncRef(
   locale,
   useStorage('locale', locale),
 );
+
+const appUpdateText = computed(() => locale.value === 'vi'
+  ? {
+      title: 'Đã có phiên bản mới',
+      description: 'ePlus.DEV Tools vừa được cập nhật. Trang sẽ đồng bộ phiên bản mới và tải lại để bạn luôn sử dụng tính năng mới nhất.',
+      legacyVersion: 'bản cũ',
+      reloadCountdown: (seconds: number) => `Tự động tải lại sau ${seconds} giây`,
+      updateNow: 'Cập nhật ngay',
+    }
+  : {
+      title: 'A new version is available',
+      description: 'ePlus.DEV Tools has just been updated. The page will sync the new version and reload so you always use the latest features.',
+      legacyVersion: 'legacy',
+      reloadCountdown: (seconds: number) => `Automatically reloading in ${seconds} seconds`,
+      updateNow: 'Update now',
+    });
 
 const updateDialogVisible = ref(false);
 const updateCountdown = ref(UPDATE_COUNTDOWN_SECONDS);
@@ -45,7 +61,7 @@ const updateProgress = computed(() => (
 
 function shortVersion(version?: string) {
   if (!version) {
-    return t('appUpdate.legacyVersion');
+    return appUpdateText.value.legacyVersion;
   }
 
   return version.length > 10 ? version.slice(0, 8) : version;
@@ -125,11 +141,11 @@ onBeforeUnmount(() => {
             :bordered="false"
             role="dialog"
             aria-modal="true"
-            :title="t('appUpdate.title')"
+            :title="appUpdateText.title"
           >
             <div class="app-update-content">
               <p class="app-update-description">
-                {{ t('appUpdate.description') }}
+                {{ appUpdateText.description }}
               </p>
 
               <div v-if="pendingUpdate" class="app-update-version">
@@ -146,13 +162,13 @@ onBeforeUnmount(() => {
               />
 
               <p class="app-update-countdown" aria-live="polite">
-                {{ t('appUpdate.reloadCountdown', { seconds: updateCountdown }) }}
+                {{ appUpdateText.reloadCountdown(updateCountdown) }}
               </p>
             </div>
 
             <template #footer>
               <NButton type="primary" block @click="reloadForUpdate">
-                {{ t('appUpdate.updateNow') }}
+                {{ appUpdateText.updateNow }}
               </NButton>
             </template>
           </NCard>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,24 @@
 <script setup lang="ts">
 import { RouterView, useRoute } from 'vue-router';
-import { NGlobalStyle, NMessageProvider, NNotificationProvider, darkTheme } from 'naive-ui';
+import {
+  NButton,
+  NCard,
+  NGlobalStyle,
+  NMessageProvider,
+  NModal,
+  NNotificationProvider,
+  NProgress,
+  darkTheme,
+} from 'naive-ui';
 import { darkThemeOverrides, lightThemeOverrides } from './themes';
 import { layouts } from './layouts';
 import { useStyleStore } from './stores/style.store';
+import {
+  DEPLOY_UPDATE_EVENT,
+  type DeployVersionMismatch,
+} from './modules/app-version/deploy-version';
+
+const UPDATE_COUNTDOWN_SECONDS = 8;
 
 const route = useRoute();
 const layout = computed(() => route?.meta?.layout ?? layouts.base);
@@ -12,12 +27,82 @@ const styleStore = useStyleStore();
 const theme = computed(() => (styleStore.isDarkTheme ? darkTheme : null));
 const themeOverrides = computed(() => (styleStore.isDarkTheme ? darkThemeOverrides : lightThemeOverrides));
 
-const { locale } = useI18n();
+const { locale, t } = useI18n();
 
 syncRef(
   locale,
   useStorage('locale', locale),
 );
+
+const updateDialogVisible = ref(false);
+const updateCountdown = ref(UPDATE_COUNTDOWN_SECONDS);
+const pendingUpdate = ref<DeployVersionMismatch>();
+let updateTimer: ReturnType<typeof setInterval> | undefined;
+
+const updateProgress = computed(() => (
+  ((UPDATE_COUNTDOWN_SECONDS - updateCountdown.value) / UPDATE_COUNTDOWN_SECONDS) * 100
+));
+
+function shortVersion(version?: string) {
+  if (!version) {
+    return t('appUpdate.legacyVersion');
+  }
+
+  return version.length > 10 ? version.slice(0, 8) : version;
+}
+
+function clearUpdateTimer() {
+  if (updateTimer !== undefined) {
+    clearInterval(updateTimer);
+    updateTimer = undefined;
+  }
+}
+
+function reloadForUpdate() {
+  clearUpdateTimer();
+  window.location.reload();
+}
+
+function startUpdateCountdown(versions: DeployVersionMismatch) {
+  if (updateDialogVisible.value) {
+    return;
+  }
+
+  pendingUpdate.value = versions;
+  updateCountdown.value = UPDATE_COUNTDOWN_SECONDS;
+  updateDialogVisible.value = true;
+  clearUpdateTimer();
+
+  updateTimer = setInterval(() => {
+    // Do not consume the countdown while the tab is hidden. The user should
+    // actually see the update notice before the page refreshes.
+    if (document.visibilityState !== 'visible') {
+      return;
+    }
+
+    if (updateCountdown.value <= 1) {
+      updateCountdown.value = 0;
+      reloadForUpdate();
+      return;
+    }
+
+    updateCountdown.value -= 1;
+  }, 1000);
+}
+
+function handleDeployUpdate(event: Event) {
+  const { detail } = event as CustomEvent<DeployVersionMismatch>;
+  startUpdateCountdown(detail);
+}
+
+onMounted(() => {
+  window.addEventListener(DEPLOY_UPDATE_EVENT, handleDeployUpdate);
+});
+
+onBeforeUnmount(() => {
+  clearUpdateTimer();
+  window.removeEventListener(DEPLOY_UPDATE_EVENT, handleDeployUpdate);
+});
 </script>
 
 <template>
@@ -28,6 +113,50 @@ syncRef(
         <component :is="layout">
           <RouterView />
         </component>
+
+        <NModal
+          v-model:show="updateDialogVisible"
+          :mask-closable="false"
+          :close-on-esc="false"
+          :auto-focus="false"
+        >
+          <NCard
+            class="app-update-card"
+            :bordered="false"
+            role="dialog"
+            aria-modal="true"
+            :title="t('appUpdate.title')"
+          >
+            <div class="app-update-content">
+              <p class="app-update-description">
+                {{ t('appUpdate.description') }}
+              </p>
+
+              <div v-if="pendingUpdate" class="app-update-version">
+                <span>{{ shortVersion(pendingUpdate.currentVersion) }}</span>
+                <span aria-hidden="true">→</span>
+                <strong>{{ shortVersion(pendingUpdate.serverVersion) }}</strong>
+              </div>
+
+              <NProgress
+                type="line"
+                :percentage="updateProgress"
+                :show-indicator="false"
+                processing
+              />
+
+              <p class="app-update-countdown" aria-live="polite">
+                {{ t('appUpdate.reloadCountdown', { seconds: updateCountdown }) }}
+              </p>
+            </div>
+
+            <template #footer>
+              <NButton type="primary" block @click="reloadForUpdate">
+                {{ t('appUpdate.updateNow') }}
+              </NButton>
+            </template>
+          </NCard>
+        </NModal>
       </NNotificationProvider>
     </NMessageProvider>
   </n-config-provider>
@@ -48,5 +177,39 @@ html {
 
 * {
   box-sizing: border-box;
+}
+
+.app-update-card {
+  width: min(440px, calc(100vw - 32px));
+}
+
+.app-update-content {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.app-update-description,
+.app-update-countdown {
+  margin: 0;
+  line-height: 1.55;
+}
+
+.app-update-countdown {
+  text-align: center;
+  font-size: 13px;
+  opacity: 0.78;
+}
+
+.app-update-version {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: 8px;
+  background: rgba(127, 127, 127, 0.1);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
 }
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,10 @@ import App from './App.vue';
 import router from './router';
 import { installGoogleAnalytics } from './plugins/google-analytics.plugin';
 import { i18nPlugin } from './plugins/i18n.plugin';
-import { createDeployVersionChecker } from './modules/app-version/deploy-version';
+import {
+  DEPLOY_UPDATE_EVENT,
+  createDeployVersionChecker,
+} from './modules/app-version/deploy-version';
 
 const checkDeployVersion = createDeployVersionChecker({
   currentVersion: import.meta.env.VITE_DEPLOY_VERSION,
@@ -20,12 +23,7 @@ const checkDeployVersion = createDeployVersionChecker({
   origin: window.location.origin,
   isOnline: () => navigator.onLine,
   fetchVersion: (url, init) => fetch(url, init),
-  reload: () => window.location.reload(),
-});
-
-void checkDeployVersion();
-window.addEventListener('pageshow', () => {
-  void checkDeployVersion();
+  onVersionMismatch: versions => window.dispatchEvent(new CustomEvent(DEPLOY_UPDATE_EVENT, { detail: versions })),
 });
 
 installGoogleAnalytics({ router });
@@ -40,3 +38,10 @@ app.use(naive);
 app.use(shadow);
 
 app.mount('#app');
+
+// Start the check only after App is mounted so the update dialog is ready to
+// receive the mismatch event. pageshow covers returning to a cached tab.
+void checkDeployVersion();
+window.addEventListener('pageshow', () => {
+  void checkDeployVersion();
+});

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -20,7 +20,7 @@ function createChecker(options: {
   const online = options.online ?? true;
   const responseOk = options.responseOk ?? true;
 
-  const reload = vi.fn();
+  const onVersionMismatch = vi.fn();
   const fetchVersion = vi.fn().mockResolvedValue(createResponse(serverVersion, responseOk));
 
   const checkDeployVersion = createDeployVersionChecker({
@@ -29,75 +29,83 @@ function createChecker(options: {
     origin: 'https://tools.eplus.dev',
     isOnline: () => online,
     fetchVersion,
-    reload,
+    onVersionMismatch,
     now: () => 1234567890,
   });
 
   return {
     checkDeployVersion,
     fetchVersion,
-    reload,
+    onVersionMismatch,
   };
 }
 
 describe('deploy version checker', () => {
-  it('reloads a legacy visitor that has no embedded deploy version', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+  it('notifies a legacy visitor that has no embedded deploy version', async () => {
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: undefined,
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(reload).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledWith({
+      currentVersion: undefined,
+      serverVersion: 'deploy-v2',
+    });
   });
 
   it('does nothing for a new visitor already running the latest deploy', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: 'deploy-v2',
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(reload).not.toHaveBeenCalled();
+    expect(onVersionMismatch).not.toHaveBeenCalled();
   });
 
-  it('reloads a returning visitor when the server has a newer deploy', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+  it('notifies a returning visitor when the server has a newer deploy', async () => {
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(reload).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledWith({
+      currentVersion: 'deploy-v1',
+      serverVersion: 'deploy-v2',
+    });
   });
 
   it('ignores a manifest that does not contain a valid version', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: undefined,
     });
 
     await checkDeployVersion();
 
-    expect(reload).not.toHaveBeenCalled();
+    expect(onVersionMismatch).not.toHaveBeenCalled();
   });
 
   it('does not fetch the version manifest while offline', async () => {
-    const { checkDeployVersion, fetchVersion, reload } = createChecker({
+    const { checkDeployVersion, fetchVersion, onVersionMismatch } = createChecker({
       online: false,
     });
 
     await checkDeployVersion();
 
     expect(fetchVersion).not.toHaveBeenCalled();
-    expect(reload).not.toHaveBeenCalled();
+    expect(onVersionMismatch).not.toHaveBeenCalled();
   });
 
   it('ignores a failed version manifest response', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: 'deploy-v2',
       responseOk: false,
@@ -105,7 +113,7 @@ describe('deploy version checker', () => {
 
     await checkDeployVersion();
 
-    expect(reload).not.toHaveBeenCalled();
+    expect(onVersionMismatch).not.toHaveBeenCalled();
   });
 
   it('uses a cache-busting version request', async () => {
@@ -125,13 +133,13 @@ describe('deploy version checker', () => {
     });
   });
 
-  it('deduplicates overlapping version checks and reloads once', async () => {
+  it('deduplicates overlapping version checks and notifies once', async () => {
     let resolveResponse!: (value: ReturnType<typeof createResponse>) => void;
     const pendingResponse = new Promise<ReturnType<typeof createResponse>>((resolve) => {
       resolveResponse = resolve;
     });
     const fetchVersion = vi.fn().mockReturnValue(pendingResponse);
-    const reload = vi.fn();
+    const onVersionMismatch = vi.fn();
 
     const checkDeployVersion = createDeployVersionChecker({
       currentVersion: 'deploy-v1',
@@ -139,7 +147,7 @@ describe('deploy version checker', () => {
       origin: 'https://tools.eplus.dev',
       isOnline: () => true,
       fetchVersion,
-      reload,
+      onVersionMismatch,
       now: () => 1234567890,
     });
 
@@ -149,6 +157,19 @@ describe('deploy version checker', () => {
     await Promise.all([firstCheck, secondCheck]);
 
     expect(fetchVersion).toHaveBeenCalledOnce();
-    expect(reload).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledOnce();
+  });
+
+  it('does not notify again on pageshow after a mismatch was already announced', async () => {
+    const { checkDeployVersion, fetchVersion, onVersionMismatch } = createChecker({
+      currentVersion: 'deploy-v1',
+      serverVersion: 'deploy-v2',
+    });
+
+    await checkDeployVersion();
+    await checkDeployVersion();
+
+    expect(fetchVersion).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledOnce();
   });
 });

--- a/src/modules/app-version/deploy-version.ts
+++ b/src/modules/app-version/deploy-version.ts
@@ -3,13 +3,20 @@ export interface VersionManifestResponse {
   json: () => Promise<unknown>
 }
 
+export interface DeployVersionMismatch {
+  currentVersion?: string
+  serverVersion: string
+}
+
+export const DEPLOY_UPDATE_EVENT = 'it-tools:deploy-update-available';
+
 export interface DeployVersionCheckerOptions {
   currentVersion?: string
   versionManifestUrl: string
   origin: string
   isOnline: () => boolean
   fetchVersion: (url: URL, init: RequestInit) => Promise<VersionManifestResponse>
-  reload: () => void
+  onVersionMismatch: (versions: DeployVersionMismatch) => void
   now?: () => number
 }
 
@@ -28,13 +35,14 @@ export function createDeployVersionChecker({
   origin,
   isOnline,
   fetchVersion,
-  reload,
+  onVersionMismatch,
   now = Date.now,
 }: DeployVersionCheckerOptions) {
   let versionCheckRunning = false;
+  let versionMismatchNotified = false;
 
   return async function checkDeployVersion() {
-    if (versionCheckRunning || !isOnline()) {
+    if (versionCheckRunning || versionMismatchNotified || !isOnline()) {
       return;
     }
 
@@ -61,10 +69,10 @@ export function createDeployVersionChecker({
         return;
       }
 
-      // HTML is served with no-store and application assets are content-hashed.
-      // Reloading directly is therefore enough to move the browser to the new
-      // deploy without depending on Service Worker lifecycle timing.
-      reload();
+      // Let the UI explain the update and show a short countdown instead of
+      // surprising the user with an immediate reload while they are working.
+      versionMismatchNotified = true;
+      onVersionMismatch({ currentVersion, serverVersion });
     }
     catch {
       // Keep the current app usable if the version endpoint is temporarily unavailable.


### PR DESCRIPTION
## Summary
- replace silent deploy-version reloads with an in-app update notice
- show current → server deploy version and an 8-second countdown
- pause the countdown while the tab is hidden so users actually see the notice
- provide an “Update now” action for immediate reload
- deduplicate repeated/pageshow mismatch notifications
- update unit tests for legacy, new, returning, overlapping, and repeated checks

## UX
When `/version.json` differs from the running bundle, the user now sees a non-dismissible update dialog before the page reloads instead of the page refreshing without explanation.

## Notes
The one-time migration from a very old legacy Service Worker can still reload before this newer UI is running; subsequent deploy-version mismatches use this dialog.