### PR TITLE
fix: show deploy build time in version tooltip

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   VITE_GOOGLE_ANALYTICS_ID?: string;
   VITE_DEPLOY_VERSION: string;
   VITE_DEPLOY_COMMIT: string;
+  VITE_DEPLOY_BUILT_AT: string;
   PACKAGE_VERSION: string;
   GIT_SHORT_SHA: string;
   PROD: boolean;

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,12 @@ export const config = figue({
       default: 'local',
       env: 'VITE_DEPLOY_VERSION',
     },
+    deployBuiltAt: {
+      doc: 'ISO timestamp when the running deployment was built',
+      format: 'string',
+      default: '',
+      env: 'VITE_DEPLOY_BUILT_AT',
+    },
     lastCommitSha: {
       doc: 'Git commit SHA for the running deployment',
       format: 'string',
@@ -67,6 +73,7 @@ export const config = figue({
     PACKAGE_VERSION: import.meta.env.PACKAGE_VERSION,
     VITE_DEPLOY_VERSION: import.meta.env.VITE_DEPLOY_VERSION,
     VITE_DEPLOY_COMMIT: import.meta.env.VITE_DEPLOY_COMMIT,
+    VITE_DEPLOY_BUILT_AT: import.meta.env.VITE_DEPLOY_BUILT_AT,
   })
   .validate()
   .getConfig();

--- a/src/layouts/base.layout.vue
+++ b/src/layouts/base.layout.vue
@@ -19,6 +19,7 @@ import CollapsibleToolMenu from '@/components/CollapsibleToolMenu.vue';
 const themeVars = useThemeVars();
 const styleStore = useStyleStore();
 const deployVersion = config.app.deployVersion;
+const deployBuiltAt = config.app.deployBuiltAt;
 const deployCommitFull = config.app.lastCommitSha;
 const deployCommit = deployCommitFull.slice(0, 7);
 const deployLabel = deployVersion.startsWith('local-') || deployVersion === 'local'
@@ -26,7 +27,39 @@ const deployLabel = deployVersion.startsWith('local-') || deployVersion === 'loc
   : deployVersion.slice(0, 8);
 
 const { tracker } = useTracker();
-const { t } = useI18n();
+const { t, locale } = useI18n();
+
+const deployBuiltAtLabel = computed(() => {
+  if (!deployBuiltAt) {
+    return '';
+  }
+
+  const date = new Date(deployBuiltAt);
+  if (Number.isNaN(date.getTime())) {
+    return deployBuiltAt;
+  }
+
+  return new Intl.DateTimeFormat(locale.value === 'vi' ? 'vi-VN' : undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short',
+  }).format(date);
+});
+
+const deployTooltip = computed(() => {
+  const builtAt = deployBuiltAtLabel.value;
+  if (!builtAt) {
+    return `Deploy ${deployVersion}`;
+  }
+
+  return locale.value === 'vi'
+    ? `Deploy ${deployVersion} · Build lúc ${builtAt}`
+    : `Deploy ${deployVersion} · Built ${builtAt}`;
+});
 
 const toolStore = useToolStore();
 const { favoriteTools, toolsByCategory } = storeToRefs(toolStore);
@@ -70,7 +103,9 @@ const tools = computed<ToolCategory[]>(() => [
         <div class="footer">
           <div class="build-meta" data-testid="deploy-build-meta">
             <span>ePlus.DEV Tools</span>
-            <span class="build-chip" :title="deployVersion">Build {{ deployLabel }}</span>
+            <c-tooltip :tooltip="deployTooltip" position="top">
+              <span class="build-chip">Build {{ deployLabel }}</span>
+            </c-tooltip>
 
             <template v-if="deployCommit">
               <span aria-hidden="true">·</span>
@@ -193,6 +228,7 @@ const tools = computed<ToolCategory[]>(() => [
   font-size: 11px;
   font-weight: 600;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  cursor: help;
 }
 
 .upstream-credit {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,6 @@ export default defineConfig({
         'vue',
         'vue-router',
         '@vueuse/core',
-        'vue-i18n',
         {
           'naive-ui': ['useDialog', 'useMessage', 'useNotification', 'useLoadingBar'],
         },
@@ -164,6 +163,7 @@ export default defineConfig({
     'import.meta.env.PACKAGE_VERSION': JSON.stringify(process.env.npm_package_version),
     'import.meta.env.VITE_DEPLOY_VERSION': JSON.stringify(deployVersion),
     'import.meta.env.VITE_DEPLOY_COMMIT': JSON.stringify(deployCommit),
+    'import.meta.env.VITE_DEPLOY_BUILT_AT': JSON.stringify(deployBuiltAt),
   },
   test: {
     exclude: [...configDefaults.exclude, '**/*.e2e.spec.ts'],


### PR DESCRIPTION
## What changed
- expose the exact `deployBuiltAt` timestamp already written to `version.json` to the client bundle
- keep it in app config alongside deploy ID and commit SHA
- replace the Build chip's plain native title with the app tooltip
- show full deploy ID plus formatted build time in the visitor's local timezone
- keep the displayed chip compact (`Build xxxxxxxx`)

Example: `builtAt: 2026-08-13T01:28:03.388Z` is shown as about `13/08/2026 08:28:03 GMT+7` for a Vietnam browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deployment build timestamp to the application configuration.
  * Display the build timestamp with locale-aware formatting.
  * Added localized tooltip support for build information.
  * Added fallback handling when the timestamp is unavailable or invalid.

* **Style**
  * Updated the build information indicator to show a help cursor and enhanced tooltip presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->