### PR TITLE
feat: add CSS unit converter

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,7 +7,10 @@ on:
       - netlify
 jobs:
   test:
-    timeout-minutes: 10
+    # The build + Playwright dependency setup can take ~2 minutes before the
+    # shard starts. Give the E2E suite enough headroom to finish instead of
+    # being cancelled by the job timeout while tests are still running.
+    timeout-minutes: 20
     # Playwright 1.32 predates Ubuntu 24.04 support. Pin Jammy until
     # Playwright is upgraded to a release that officially supports Noble.
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,14 +7,14 @@ on:
       - netlify
 jobs:
   test:
-    # The build + Playwright dependency setup can take ~2 minutes before the
-    # shard starts. Give the E2E suite enough headroom to finish instead of
-    # being cancelled by the job timeout while tests are still running.
-    timeout-minutes: 20
+    timeout-minutes: 12
     # Playwright 1.32 predates Ubuntu 24.04 support. Pin Jammy until
     # Playwright is upgraded to a release that officially supports Noble.
     runs-on: ubuntu-22.04
     strategy:
+      # Keep only one E2E shard on a runner at a time so this repository does
+      # not occupy all available GitHub-hosted runners while other repos run.
+      max-parallel: 1
       matrix:
         shard: [1/3, 2/3, 3/3]
     steps:

--- a/src/tools/css-unit-converter/css-unit-converter.service.test.ts
+++ b/src/tools/css-unit-converter/css-unit-converter.service.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  convertCssUnitToPx,
+  convertPxToCssUnit,
+  formatCssUnitValue,
+  getCssUnitFormula,
+} from './css-unit-converter.service';
+
+describe('CSS unit converter service', () => {
+  it('converts PX to REM and REM to PX', () => {
+    expect(convertPxToCssUnit(16, 'rem', 16)).toBe(1);
+    expect(convertPxToCssUnit(24, 'rem', 16)).toBe(1.5);
+    expect(convertCssUnitToPx(1.5, 'rem', 16)).toBe(24);
+  });
+
+  it('converts PX to EM and EM to PX using the parent font size', () => {
+    expect(convertPxToCssUnit(20, 'em', 16)).toBe(1.25);
+    expect(convertCssUnitToPx(2, 'em', 18)).toBe(36);
+  });
+
+  it('converts PX to percentage and percentage to PX using the reference size', () => {
+    expect(convertPxToCssUnit(250, '%', 1000)).toBe(25);
+    expect(convertCssUnitToPx(25, '%', 1000)).toBe(250);
+  });
+
+  it('supports negative CSS values', () => {
+    expect(convertPxToCssUnit(-8, 'rem', 16)).toBe(-0.5);
+    expect(convertCssUnitToPx(-0.5, 'rem', 16)).toBe(-8);
+  });
+
+  it('rejects invalid or non-positive reference sizes', () => {
+    expect(convertPxToCssUnit(16, 'rem', 0)).toBeNull();
+    expect(convertCssUnitToPx(1, 'em', -16)).toBeNull();
+    expect(convertPxToCssUnit(Number.NaN, 'rem', 16)).toBeNull();
+  });
+
+  it('rounds floating point results for copy-friendly CSS values', () => {
+    expect(convertPxToCssUnit(10, 'rem', 16)).toBe(0.625);
+    expect(convertPxToCssUnit(1, 'rem', 3)).toBe(0.333333);
+    expect(formatCssUnitValue(0.333333)).toBe('0.333333');
+  });
+
+  it('builds readable formulas for each supported conversion family', () => {
+    expect(getCssUnitFormula({
+      value: 24,
+      unit: 'rem',
+      referencePx: 16,
+      direction: 'px-to-relative',
+      result: 1.5,
+    })).toBe('24px ÷ 16px = 1.5rem');
+
+    expect(getCssUnitFormula({
+      value: 25,
+      unit: '%',
+      referencePx: 1000,
+      direction: 'relative-to-px',
+      result: 250,
+    })).toBe('25% ÷ 100 × 1000px = 250px');
+  });
+});

--- a/src/tools/css-unit-converter/css-unit-converter.service.ts
+++ b/src/tools/css-unit-converter/css-unit-converter.service.ts
@@ -1,0 +1,78 @@
+export type CssRelativeUnit = 'rem' | 'em' | '%';
+
+export const CSS_UNIT_DEFAULT_REFERENCES: Record<CssRelativeUnit, number> = {
+  rem: 16,
+  em: 16,
+  '%': 100,
+};
+
+export function roundCssUnitValue(value: number, precision = 6) {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  const factor = 10 ** precision;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+export function convertPxToCssUnit(px: number, unit: CssRelativeUnit, referencePx: number) {
+  if (!Number.isFinite(px) || !Number.isFinite(referencePx) || referencePx <= 0) {
+    return null;
+  }
+
+  const converted = unit === '%'
+    ? (px / referencePx) * 100
+    : px / referencePx;
+
+  return roundCssUnitValue(converted);
+}
+
+export function convertCssUnitToPx(value: number, unit: CssRelativeUnit, referencePx: number) {
+  if (!Number.isFinite(value) || !Number.isFinite(referencePx) || referencePx <= 0) {
+    return null;
+  }
+
+  const converted = unit === '%'
+    ? (value / 100) * referencePx
+    : value * referencePx;
+
+  return roundCssUnitValue(converted);
+}
+
+export function formatCssUnitValue(value: number | null) {
+  if (value === null || !Number.isFinite(value)) {
+    return '—';
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 6,
+    useGrouping: false,
+  }).format(value);
+}
+
+export function getCssUnitFormula(options: {
+  value: number
+  unit: CssRelativeUnit
+  referencePx: number
+  direction: 'px-to-relative' | 'relative-to-px'
+  result: number
+}) {
+  const { value, unit, referencePx, direction, result } = options;
+  const source = formatCssUnitValue(value);
+  const reference = formatCssUnitValue(referencePx);
+  const output = formatCssUnitValue(result);
+
+  if (direction === 'px-to-relative') {
+    if (unit === '%') {
+      return `${source}px ÷ ${reference}px × 100 = ${output}%`;
+    }
+
+    return `${source}px ÷ ${reference}px = ${output}${unit}`;
+  }
+
+  if (unit === '%') {
+    return `${source}% ÷ 100 × ${reference}px = ${output}px`;
+  }
+
+  return `${source}${unit} × ${reference}px = ${output}px`;
+}

--- a/src/tools/css-unit-converter/css-unit-converter.service.ts
+++ b/src/tools/css-unit-converter/css-unit-converter.service.ts
@@ -1,8 +1,8 @@
 export type CssRelativeUnit = 'rem' | 'em' | '%';
 
 export const CSS_UNIT_DEFAULT_REFERENCES: Record<CssRelativeUnit, number> = {
-  rem: 16,
-  em: 16,
+  'rem': 16,
+  'em': 16,
   '%': 100,
 };
 

--- a/src/tools/css-unit-converter/css-unit-converter.vue
+++ b/src/tools/css-unit-converter/css-unit-converter.vue
@@ -1,0 +1,478 @@
+<script setup lang="ts">
+import {
+  CSS_UNIT_DEFAULT_REFERENCES,
+  type CssRelativeUnit,
+  convertCssUnitToPx,
+  convertPxToCssUnit,
+  formatCssUnitValue,
+  getCssUnitFormula,
+} from './css-unit-converter.service';
+
+type PairId = 'rem' | 'em' | 'percent';
+type Direction = 'px-to-relative' | 'relative-to-px';
+
+const { locale } = useI18n();
+const isVietnamese = computed(() => locale.value === 'vi');
+
+const copyState = ref<'idle' | 'copied'>('idle');
+const pair = ref<PairId>('rem');
+const direction = ref<Direction>('px-to-relative');
+const inputValue = ref<number | null>(16);
+const referencePx = ref<number | null>(CSS_UNIT_DEFAULT_REFERENCES.rem);
+
+const pairConfig: Record<PairId, {
+  relativeUnit: CssRelativeUnit
+  label: string
+  referenceLabel: { en: string; vi: string }
+  referenceHint: { en: string; vi: string }
+}> = {
+  rem: {
+    relativeUnit: 'rem',
+    label: 'PX ↔ REM',
+    referenceLabel: { en: 'Root font size', vi: 'Cỡ chữ gốc (root)' },
+    referenceHint: {
+      en: 'REM is relative to the root <html> font size. Browsers commonly default to 16px.',
+      vi: 'REM dựa trên cỡ chữ của phần tử <html>. Trình duyệt thường mặc định là 16px.',
+    },
+  },
+  em: {
+    relativeUnit: 'em',
+    label: 'PX ↔ EM',
+    referenceLabel: { en: 'Parent font size', vi: 'Cỡ chữ phần tử cha' },
+    referenceHint: {
+      en: 'EM is relative to the relevant inherited/current font size. Set the parent/context size used by your CSS.',
+      vi: 'EM phụ thuộc vào cỡ chữ của phần tử cha/ngữ cảnh hiện tại. Nhập cỡ chữ đang được CSS sử dụng.',
+    },
+  },
+  percent: {
+    relativeUnit: '%',
+    label: 'PX ↔ %',
+    referenceLabel: { en: 'Reference size', vi: 'Kích thước tham chiếu' },
+    referenceHint: {
+      en: 'Percentage needs a reference dimension. For example, 250px is 25% of a 1000px container.',
+      vi: 'Phần trăm cần kích thước tham chiếu. Ví dụ 250px bằng 25% của container 1000px.',
+    },
+  },
+};
+
+const text = computed(() => isVietnamese.value
+  ? {
+      intro: 'Chuyển đổi nhanh giữa PX và các đơn vị CSS tương đối. Chọn nhóm đơn vị, nhập kích thước tham chiếu rồi đổi theo cả hai chiều.',
+      value: 'Giá trị cần đổi',
+      result: 'Kết quả',
+      reference: pairConfig[pair.value].referenceLabel.vi,
+      hint: pairConfig[pair.value].referenceHint.vi,
+      swap: 'Đổi chiều',
+      copy: 'Sao chép',
+      copied: 'Đã sao chép',
+      invalidReference: 'Kích thước tham chiếu phải lớn hơn 0px.',
+      presets: 'Giá trị nhanh',
+      pxToRelative: `PX → ${pairConfig[pair.value].relativeUnit.toUpperCase()}`,
+      relativeToPx: `${pairConfig[pair.value].relativeUnit.toUpperCase()} → PX`,
+    }
+  : {
+      intro: 'Quickly convert between PX and relative CSS units. Choose a unit family, set its reference size, and convert in either direction.',
+      value: 'Value to convert',
+      result: 'Result',
+      reference: pairConfig[pair.value].referenceLabel.en,
+      hint: pairConfig[pair.value].referenceHint.en,
+      swap: 'Swap direction',
+      copy: 'Copy',
+      copied: 'Copied',
+      invalidReference: 'Reference size must be greater than 0px.',
+      presets: 'Quick values',
+      pxToRelative: `PX → ${pairConfig[pair.value].relativeUnit.toUpperCase()}`,
+      relativeToPx: `${pairConfig[pair.value].relativeUnit.toUpperCase()} → PX`,
+    });
+
+const currentRelativeUnit = computed(() => pairConfig[pair.value].relativeUnit);
+const validReference = computed(() => referencePx.value !== null && Number.isFinite(referencePx.value) && referencePx.value > 0);
+
+const result = computed(() => {
+  if (inputValue.value === null || !Number.isFinite(inputValue.value) || !validReference.value || referencePx.value === null) {
+    return null;
+  }
+
+  return direction.value === 'px-to-relative'
+    ? convertPxToCssUnit(inputValue.value, currentRelativeUnit.value, referencePx.value)
+    : convertCssUnitToPx(inputValue.value, currentRelativeUnit.value, referencePx.value);
+});
+
+const sourceUnit = computed(() => direction.value === 'px-to-relative' ? 'px' : currentRelativeUnit.value);
+const targetUnit = computed(() => direction.value === 'px-to-relative' ? currentRelativeUnit.value : 'px');
+const resultText = computed(() => result.value === null ? '—' : `${formatCssUnitValue(result.value)}${targetUnit.value}`);
+
+const formula = computed(() => {
+  if (result.value === null || inputValue.value === null || referencePx.value === null) {
+    return '—';
+  }
+
+  return getCssUnitFormula({
+    value: inputValue.value,
+    unit: currentRelativeUnit.value,
+    referencePx: referencePx.value,
+    direction: direction.value,
+    result: result.value,
+  });
+});
+
+const presets = computed(() => {
+  if (direction.value === 'px-to-relative') {
+    return [8, 12, 14, 16, 18, 20, 24, 32, 48, 64];
+  }
+
+  return currentRelativeUnit.value === '%'
+    ? [10, 25, 50, 75, 100, 125, 150]
+    : [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+});
+
+watch(pair, (nextPair) => {
+  referencePx.value = CSS_UNIT_DEFAULT_REFERENCES[pairConfig[nextPair].relativeUnit];
+  copyState.value = 'idle';
+});
+
+watch([inputValue, referencePx, direction], () => {
+  copyState.value = 'idle';
+});
+
+function swapDirection() {
+  const previousResult = result.value;
+  direction.value = direction.value === 'px-to-relative' ? 'relative-to-px' : 'px-to-relative';
+
+  if (previousResult !== null) {
+    inputValue.value = previousResult;
+  }
+}
+
+async function copyResult() {
+  if (result.value === null) {
+    return;
+  }
+
+  await navigator.clipboard.writeText(resultText.value);
+  copyState.value = 'copied';
+  window.setTimeout(() => {
+    copyState.value = 'idle';
+  }, 1400);
+}
+</script>
+
+<template>
+  <div class="css-unit-converter">
+    <p class="intro">
+      {{ text.intro }}
+    </p>
+
+    <n-radio-group v-model:value="pair" size="large" class="mode-selector">
+      <n-radio-button v-for="(config, key) in pairConfig" :key="key" :value="key">
+        {{ config.label }}
+      </n-radio-button>
+    </n-radio-group>
+
+    <div class="converter-card">
+      <div class="direction-row">
+        <n-radio-group v-model:value="direction" size="small">
+          <n-radio-button value="px-to-relative">
+            {{ text.pxToRelative }}
+          </n-radio-button>
+          <n-radio-button value="relative-to-px">
+            {{ text.relativeToPx }}
+          </n-radio-button>
+        </n-radio-group>
+
+        <n-button secondary @click="swapDirection">
+          ⇄ {{ text.swap }}
+        </n-button>
+      </div>
+
+      <div class="conversion-grid">
+        <div class="field-block">
+          <div class="field-label">
+            {{ text.value }}
+          </div>
+          <n-input-group>
+            <n-input-number
+              v-model:value="inputValue"
+              :show-button="false"
+              :placeholder="direction === 'px-to-relative' ? '16' : '1'"
+              class="number-input"
+            />
+            <n-input-group-label class="unit-label">
+              {{ sourceUnit }}
+            </n-input-group-label>
+          </n-input-group>
+        </div>
+
+        <div class="equals" aria-hidden="true">
+          =
+        </div>
+
+        <div class="result-block">
+          <div class="field-label">
+            {{ text.result }}
+          </div>
+          <div class="result-value">
+            <strong>{{ resultText }}</strong>
+            <n-button size="small" quaternary :disabled="result === null" @click="copyResult">
+              {{ copyState === 'copied' ? text.copied : text.copy }}
+            </n-button>
+          </div>
+        </div>
+      </div>
+
+      <div class="reference-section">
+        <div class="field-label">
+          {{ text.reference }}
+        </div>
+        <n-input-group>
+          <n-input-number
+            v-model:value="referencePx"
+            :min="0.000001"
+            :show-button="false"
+            class="number-input"
+          />
+          <n-input-group-label class="unit-label">
+            px
+          </n-input-group-label>
+        </n-input-group>
+        <p class="reference-hint">
+          {{ text.hint }}
+        </p>
+        <n-alert v-if="!validReference" type="error" :show-icon="false" mt-2>
+          {{ text.invalidReference }}
+        </n-alert>
+      </div>
+
+      <div class="formula">
+        <code>{{ formula }}</code>
+      </div>
+    </div>
+
+    <div class="presets">
+      <span>{{ text.presets }}</span>
+      <div class="preset-buttons">
+        <n-button v-for="preset in presets" :key="preset" size="tiny" secondary @click="inputValue = preset">
+          {{ preset }}{{ sourceUnit }}
+        </n-button>
+      </div>
+    </div>
+
+    <div class="examples-grid">
+      <div>
+        <strong>PX ↔ REM</strong>
+        <span>16px ↔ 1rem · 24px ↔ 1.5rem</span>
+      </div>
+      <div>
+        <strong>PX ↔ EM</strong>
+        <span>16px ↔ 1em · 32px ↔ 2em</span>
+      </div>
+      <div>
+        <strong>PX ↔ %</strong>
+        <span>250px ↔ 25% @ 1000px</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.css-unit-converter {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.intro {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.78;
+}
+
+.mode-selector {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  width: 100%;
+}
+
+.mode-selector :deep(.n-radio-button) {
+  width: 100%;
+  text-align: center;
+}
+
+.converter-card {
+  padding: 20px;
+  border: 1px solid rgba(127, 127, 127, 0.2);
+  border-radius: 14px;
+  background: rgba(127, 127, 127, 0.04);
+}
+
+.direction-row,
+.result-value,
+.presets,
+.preset-buttons {
+  display: flex;
+  align-items: center;
+}
+
+.direction-row {
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.conversion-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: end;
+  gap: 14px;
+}
+
+.field-block,
+.result-block,
+.reference-section {
+  min-width: 0;
+}
+
+.field-label {
+  margin-bottom: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0.72;
+}
+
+.number-input {
+  width: 100%;
+}
+
+.unit-label {
+  width: 58px;
+  justify-content: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-transform: lowercase;
+}
+
+.equals {
+  padding-bottom: 8px;
+  font-size: 22px;
+  opacity: 0.45;
+}
+
+.result-value {
+  justify-content: space-between;
+  min-height: 34px;
+  gap: 8px;
+  padding: 0 4px;
+}
+
+.result-value strong {
+  overflow-wrap: anywhere;
+  font-size: 22px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.reference-section {
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(127, 127, 127, 0.16);
+}
+
+.reference-section .n-input-group {
+  max-width: 280px;
+}
+
+.reference-hint {
+  margin: 8px 0 0;
+  font-size: 12px;
+  line-height: 1.55;
+  opacity: 0.62;
+}
+
+.formula {
+  margin-top: 16px;
+  padding: 11px 12px;
+  overflow-x: auto;
+  border-radius: 8px;
+  background: rgba(127, 127, 127, 0.1);
+  text-align: center;
+}
+
+.formula code {
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.presets {
+  align-items: flex-start;
+  gap: 12px;
+  font-size: 12px;
+  opacity: 0.9;
+}
+
+.presets > span {
+  flex: none;
+  padding-top: 4px;
+  font-weight: 600;
+}
+
+.preset-buttons {
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.examples-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.examples-grid > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 11px 12px;
+  border: 1px solid rgba(127, 127, 127, 0.16);
+  border-radius: 10px;
+  font-size: 11px;
+}
+
+.examples-grid span {
+  opacity: 0.62;
+}
+
+@media (max-width: 640px) {
+  .converter-card {
+    padding: 15px;
+  }
+
+  .direction-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .direction-row :deep(.n-radio-group) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .direction-row :deep(.n-radio-button) {
+    width: 100%;
+    text-align: center;
+  }
+
+  .conversion-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .equals {
+    display: none;
+  }
+
+  .examples-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .presets {
+    flex-direction: column;
+    gap: 7px;
+  }
+}
+</style>

--- a/src/tools/css-unit-converter/index.ts
+++ b/src/tools/css-unit-converter/index.ts
@@ -1,0 +1,28 @@
+import { Code } from '@vicons/tabler';
+import { defineTool } from '../tool';
+
+export const tool = defineTool({
+  name: 'CSS unit converter',
+  path: '/css-unit-converter',
+  description: 'Convert CSS values between PX and REM, EM, or percentage with configurable root, parent, and reference sizes.',
+  keywords: [
+    'css',
+    'unit',
+    'converter',
+    'px to rem',
+    'rem to px',
+    'px to em',
+    'em to px',
+    'px to percentage',
+    'percentage to px',
+    'pixel',
+    'rem',
+    'em',
+    'percent',
+    'font size',
+    'responsive design',
+  ],
+  component: () => import('./css-unit-converter.vue'),
+  icon: Code,
+  createdAt: new Date('2026-08-13'),
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -58,6 +58,7 @@ import { tool as caseConverter } from './case-converter';
 import { tool as chmodCalculator } from './chmod-calculator';
 import { tool as chronometer } from './chronometer';
 import { tool as colorConverter } from './color-converter';
+import { tool as cssUnitConverter } from './css-unit-converter';
 import { tool as crontabGenerator } from './crontab-generator';
 import { tool as dateTimeConverter } from './date-time-converter';
 import { tool as deviceInformation } from './device-information';
@@ -105,6 +106,7 @@ const coreCategories: ToolCategory[] = [
     name: 'Converter',
     components: [
       dateTimeConverter,
+      cssUnitConverter,
       baseConverter,
       romanNumeralConverter,
       base64StringConverter,


### PR DESCRIPTION
## What changed
- add a new **CSS unit converter** under the Converter category
- support all requested directions in one focused tool:
  - PX → REM and REM → PX
  - PX → EM and EM → PX
  - PX → percentage and percentage → PX
- allow configurable root font size, parent font size, or percentage reference size
- provide one-click direction swapping while preserving the equivalent value
- show the exact conversion formula and copy-ready result
- add quick-value presets and responsive mobile layout
- add search keywords for every requested converter phrase
- add unit tests for REM, EM, percentage, negative values, invalid references, rounding, and formula output

## Why one tool instead of six pages
These conversions share the same workflow and differ mainly by the reference size. A single CSS unit converter keeps discovery simple while still matching searches such as `px to rem`, `rem to px`, `px to em`, `em to px`, `px to percentage`, and `percentage to px`.