### PR TITLE
fix: prevent deploy update reload loops and e2e hard timeouts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,11 +7,15 @@ on:
       - netlify
 jobs:
   test:
-    timeout-minutes: 10
+    # Playwright has its own 9-minute global timeout. Keep a small buffer here
+    # for dependency installation/build so failures are reported by Playwright
+    # instead of appearing as an unexplained GitHub cancellation.
+    timeout-minutes: 15
     # Playwright 1.32 predates Ubuntu 24.04 support. Pin Jammy until
     # Playwright is upgraded to a release that officially supports Noble.
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         shard: [1/3, 2/3, 3/3]
     steps:
@@ -37,6 +41,7 @@ jobs:
         run: pnpm build
 
       - name: Restore Playwright browsers from cache
+        id: playwright-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
@@ -45,8 +50,12 @@ jobs:
             ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}-
             ${{ runner.os }}-playwright-
 
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
+      - name: Install Playwright system dependencies
+        run: pnpm exec playwright install-deps
+
+      - name: Install Playwright browsers on cache miss
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install
 
       - name: Run Playwright tests
         run: pnpm run test:e2e --shard=${{ matrix.shard }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,14 +12,21 @@ export default defineConfig({
   testMatch: /\.e2e\.(spec\.)?ts$/,
   /* Run tests in files in parallel */
   fullyParallel: true,
+  /* Stop inside Playwright with useful output instead of waiting for the GitHub job hard timeout. */
+  globalTimeout: isCI ? 9 * 60 * 1000 : 0,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: isCI,
-  /* Retry on CI only */
-  retries: isCI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: isCI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* Keep one retry on CI without tripling a slow shard. */
+  retries: isCI ? 1 : 0,
+  /* Two workers per shard keeps the cross-browser suite below the job timeout. */
+  workers: isCI ? 2 : undefined,
+  /* Stream progress in Actions while preserving an HTML report for diagnostics. */
+  reporter: isCI
+    ? [
+        ['line'],
+        ['html', { open: 'never' }],
+      ]
+    : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -51,14 +58,14 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
-
+  /* Run your local preview server before starting the tests. */
   ...(useWebServer
     && {
       webServer: {
         command: 'npm run preview',
         url: 'http://localhost:5050',
         reuseExistingServer: !isCI,
+        timeout: 60 * 1000,
       },
     }
   ),

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { RouterView, useRoute } from 'vue-router';
 import {
+  NAlert,
   NButton,
   NCard,
   NGlobalStyle,
@@ -16,6 +17,8 @@ import { useStyleStore } from './stores/style.store';
 import {
   DEPLOY_UPDATE_EVENT,
   type DeployVersionMismatch,
+  createDeployUpdateUrl,
+  hasAttemptedDeployUpdate,
 } from './modules/app-version/deploy-version';
 
 const UPDATE_COUNTDOWN_SECONDS = 8;
@@ -41,6 +44,8 @@ const appUpdateText = computed(() => locale.value === 'vi'
       legacyVersion: 'bản cũ',
       reloadCountdown: (seconds: number) => `Tự động tải lại sau ${seconds} giây`,
       updateNow: 'Cập nhật ngay',
+      reloadLoopStopped: 'Trình duyệt vẫn đang giữ phiên bản cũ sau lần tải lại trước. Hệ thống đã dừng tự động tải lại để tránh vòng lặp và trang trắng. Bạn có thể thử tải phiên bản mới lại một lần nữa.',
+      retryUpdate: 'Thử tải phiên bản mới',
     }
   : {
       title: 'A new version is available',
@@ -48,11 +53,14 @@ const appUpdateText = computed(() => locale.value === 'vi'
       legacyVersion: 'legacy',
       reloadCountdown: (seconds: number) => `Automatically reloading in ${seconds} seconds`,
       updateNow: 'Update now',
+      reloadLoopStopped: 'The browser is still holding the previous version after a reload. Automatic reloads have been stopped to prevent a loop or blank page. You can try loading the new version once more.',
+      retryUpdate: 'Try loading the new version',
     });
 
 const updateDialogVisible = ref(false);
 const updateCountdown = ref(UPDATE_COUNTDOWN_SECONDS);
 const pendingUpdate = ref<DeployVersionMismatch>();
+const automaticReloadBlocked = ref(false);
 let updateTimer: ReturnType<typeof setInterval> | undefined;
 
 const updateProgress = computed(() => (
@@ -76,7 +84,17 @@ function clearUpdateTimer() {
 
 function reloadForUpdate() {
   clearUpdateTimer();
-  window.location.reload();
+
+  const serverVersion = pendingUpdate.value?.serverVersion;
+  if (!serverVersion) {
+    return;
+  }
+
+  // A normal location.reload() can reuse stale HTML in some browsers. Put the
+  // target deploy in the URL so the navigation is a fresh document request.
+  // If that exact deploy still does not load, the next app boot detects this
+  // marker and stops auto-reloading instead of entering a refresh loop.
+  window.location.replace(createDeployUpdateUrl(window.location.href, serverVersion));
 }
 
 function startUpdateCountdown(versions: DeployVersionMismatch) {
@@ -85,9 +103,14 @@ function startUpdateCountdown(versions: DeployVersionMismatch) {
   }
 
   pendingUpdate.value = versions;
-  updateCountdown.value = UPDATE_COUNTDOWN_SECONDS;
+  automaticReloadBlocked.value = hasAttemptedDeployUpdate(window.location.href, versions.serverVersion);
+  updateCountdown.value = automaticReloadBlocked.value ? 0 : UPDATE_COUNTDOWN_SECONDS;
   updateDialogVisible.value = true;
   clearUpdateTimer();
+
+  if (automaticReloadBlocked.value) {
+    return;
+  }
 
   updateTimer = setInterval(() => {
     // Do not consume the countdown while the tab is hidden. The user should
@@ -154,21 +177,27 @@ onBeforeUnmount(() => {
                 <strong>{{ shortVersion(pendingUpdate.serverVersion) }}</strong>
               </div>
 
-              <NProgress
-                type="line"
-                :percentage="updateProgress"
-                :show-indicator="false"
-                processing
-              />
+              <NAlert v-if="automaticReloadBlocked" type="warning" :show-icon="true">
+                {{ appUpdateText.reloadLoopStopped }}
+              </NAlert>
 
-              <p class="app-update-countdown" aria-live="polite">
-                {{ appUpdateText.reloadCountdown(updateCountdown) }}
-              </p>
+              <template v-else>
+                <NProgress
+                  type="line"
+                  :percentage="updateProgress"
+                  :show-indicator="false"
+                  processing
+                />
+
+                <p class="app-update-countdown" aria-live="polite">
+                  {{ appUpdateText.reloadCountdown(updateCountdown) }}
+                </p>
+              </template>
             </div>
 
             <template #footer>
               <NButton type="primary" block @click="reloadForUpdate">
-                {{ appUpdateText.updateNow }}
+                {{ automaticReloadBlocked ? appUpdateText.retryUpdate : appUpdateText.updateNow }}
               </NButton>
             </template>
           </NCard>

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,11 +14,19 @@ import { installGoogleAnalytics } from './plugins/google-analytics.plugin';
 import { i18nPlugin } from './plugins/i18n.plugin';
 import {
   DEPLOY_UPDATE_EVENT,
+  clearCompletedDeployUpdateMarker,
   createDeployVersionChecker,
+  shouldCheckDeployVersion,
 } from './modules/app-version/deploy-version';
 
+const deployVersion = import.meta.env.VITE_DEPLOY_VERSION;
+const completedUpdatePath = clearCompletedDeployUpdateMarker(window.location.href, deployVersion);
+if (completedUpdatePath) {
+  window.history.replaceState(window.history.state, '', completedUpdatePath);
+}
+
 const checkDeployVersion = createDeployVersionChecker({
-  currentVersion: import.meta.env.VITE_DEPLOY_VERSION,
+  currentVersion: deployVersion,
   versionManifestUrl: `${import.meta.env.BASE_URL}version.json`,
   origin: window.location.origin,
   isOnline: () => navigator.onLine,
@@ -39,9 +47,13 @@ app.use(shadow);
 
 app.mount('#app');
 
-// Start the check only after App is mounted so the update dialog is ready to
-// receive the mismatch event. pageshow covers returning to a cached tab.
-void checkDeployVersion();
-window.addEventListener('pageshow', () => {
+// Local Vite previews are used by Playwright. They are immutable build
+// snapshots, so deploy polling only adds noise and can interrupt navigation.
+// Production/custom domains still check version.json after App is mounted so
+// the update dialog is ready before a mismatch event can be emitted.
+if (shouldCheckDeployVersion(window.location.hostname)) {
   void checkDeployVersion();
-});
+  window.addEventListener('pageshow', () => {
+    void checkDeployVersion();
+  });
+}

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createDeployVersionChecker } from './deploy-version';
+import {
+  clearCompletedDeployUpdateMarker,
+  createDeployUpdateUrl,
+  createDeployVersionChecker,
+  hasAttemptedDeployUpdate,
+  shouldCheckDeployVersion,
+} from './deploy-version';
 
 function createResponse(version?: string, ok = true) {
   return {
@@ -171,5 +177,36 @@ describe('deploy version checker', () => {
 
     expect(fetchVersion).toHaveBeenCalledOnce();
     expect(onVersionMismatch).toHaveBeenCalledOnce();
+  });
+});
+
+describe('deploy update navigation guards', () => {
+  it('skips deploy polling on local preview hosts used by Playwright', () => {
+    expect(shouldCheckDeployVersion('localhost')).toBe(false);
+    expect(shouldCheckDeployVersion('127.0.0.1')).toBe(false);
+    expect(shouldCheckDeployVersion('[::1]')).toBe(false);
+    expect(shouldCheckDeployVersion('tools.eplus.dev')).toBe(true);
+  });
+
+  it('adds the target deploy as a cache-busting reload marker', () => {
+    expect(createDeployUpdateUrl('https://tools.eplus.dev/vietqr-bank-generator?bank=970436#qr', 'deploy-v2'))
+      .toBe('https://tools.eplus.dev/vietqr-bank-generator?bank=970436&__eplus_update=deploy-v2#qr');
+  });
+
+  it('detects when the browser already reloaded for the same deploy', () => {
+    expect(hasAttemptedDeployUpdate('https://tools.eplus.dev/?__eplus_update=deploy-v2', 'deploy-v2')).toBe(true);
+    expect(hasAttemptedDeployUpdate('https://tools.eplus.dev/?__eplus_update=deploy-v1', 'deploy-v2')).toBe(false);
+  });
+
+  it('cleans a successful deploy marker without losing the route or query', () => {
+    expect(clearCompletedDeployUpdateMarker(
+      'https://tools.eplus.dev/vietqr-bank-generator?bank=970436&__eplus_update=deploy-v2#qr',
+      'deploy-v2',
+    )).toBe('/vietqr-bank-generator?bank=970436#qr');
+
+    expect(clearCompletedDeployUpdateMarker(
+      'https://tools.eplus.dev/?__eplus_update=deploy-v1',
+      'deploy-v2',
+    )).toBeUndefined();
   });
 });

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -188,24 +188,27 @@ describe('deploy update navigation guards', () => {
     expect(shouldCheckDeployVersion('tools.eplus.dev')).toBe(true);
   });
 
-  it('adds the target deploy as a cache-busting reload marker', () => {
-    expect(createDeployUpdateUrl('https://tools.eplus.dev/vietqr-bank-generator?bank=970436#qr', 'deploy-v2'))
-      .toBe('https://tools.eplus.dev/vietqr-bank-generator?bank=970436&__eplus_update=deploy-v2#qr');
+  it('adds the target deploy and a fresh reload nonce to the navigation URL', () => {
+    expect(createDeployUpdateUrl(
+      'https://tools.eplus.dev/vietqr-bank-generator?bank=970436#qr',
+      'deploy-v2',
+      1234567890,
+    )).toBe('https://tools.eplus.dev/vietqr-bank-generator?bank=970436&__eplus_update=deploy-v2&__eplus_reload=1234567890#qr');
   });
 
   it('detects when the browser already reloaded for the same deploy', () => {
-    expect(hasAttemptedDeployUpdate('https://tools.eplus.dev/?__eplus_update=deploy-v2', 'deploy-v2')).toBe(true);
-    expect(hasAttemptedDeployUpdate('https://tools.eplus.dev/?__eplus_update=deploy-v1', 'deploy-v2')).toBe(false);
+    expect(hasAttemptedDeployUpdate('https://tools.eplus.dev/?__eplus_update=deploy-v2&__eplus_reload=1', 'deploy-v2')).toBe(true);
+    expect(hasAttemptedDeployUpdate('https://tools.eplus.dev/?__eplus_update=deploy-v1&__eplus_reload=1', 'deploy-v2')).toBe(false);
   });
 
-  it('cleans a successful deploy marker without losing the route or query', () => {
+  it('cleans successful deploy markers without losing the route or user query', () => {
     expect(clearCompletedDeployUpdateMarker(
-      'https://tools.eplus.dev/vietqr-bank-generator?bank=970436&__eplus_update=deploy-v2#qr',
+      'https://tools.eplus.dev/vietqr-bank-generator?bank=970436&__eplus_update=deploy-v2&__eplus_reload=1234567890#qr',
       'deploy-v2',
     )).toBe('/vietqr-bank-generator?bank=970436#qr');
 
     expect(clearCompletedDeployUpdateMarker(
-      'https://tools.eplus.dev/?__eplus_update=deploy-v1',
+      'https://tools.eplus.dev/?__eplus_update=deploy-v1&__eplus_reload=1234567890',
       'deploy-v2',
     )).toBeUndefined();
   });

--- a/src/modules/app-version/deploy-version.ts
+++ b/src/modules/app-version/deploy-version.ts
@@ -10,6 +10,7 @@ export interface DeployVersionMismatch {
 
 export const DEPLOY_UPDATE_EVENT = 'it-tools:deploy-update-available';
 export const DEPLOY_UPDATE_QUERY_PARAM = '__eplus_update';
+export const DEPLOY_UPDATE_RELOAD_PARAM = '__eplus_reload';
 
 export interface DeployVersionCheckerOptions {
   currentVersion?: string
@@ -35,9 +36,10 @@ export function shouldCheckDeployVersion(hostname: string) {
   return !['localhost', '127.0.0.1', '::1'].includes(normalizedHostname);
 }
 
-export function createDeployUpdateUrl(currentHref: string, serverVersion: string) {
+export function createDeployUpdateUrl(currentHref: string, serverVersion: string, reloadNonce = Date.now()) {
   const url = new URL(currentHref);
   url.searchParams.set(DEPLOY_UPDATE_QUERY_PARAM, serverVersion);
+  url.searchParams.set(DEPLOY_UPDATE_RELOAD_PARAM, reloadNonce.toString());
   return url.toString();
 }
 
@@ -58,6 +60,7 @@ export function clearCompletedDeployUpdateMarker(currentHref: string, currentVer
     }
 
     url.searchParams.delete(DEPLOY_UPDATE_QUERY_PARAM);
+    url.searchParams.delete(DEPLOY_UPDATE_RELOAD_PARAM);
     return `${url.pathname}${url.search}${url.hash}`;
   }
   catch {

--- a/src/modules/app-version/deploy-version.ts
+++ b/src/modules/app-version/deploy-version.ts
@@ -9,6 +9,7 @@ export interface DeployVersionMismatch {
 }
 
 export const DEPLOY_UPDATE_EVENT = 'it-tools:deploy-update-available';
+export const DEPLOY_UPDATE_QUERY_PARAM = '__eplus_update';
 
 export interface DeployVersionCheckerOptions {
   currentVersion?: string
@@ -27,6 +28,41 @@ function getManifestVersion(manifest: unknown) {
 
   const { version } = manifest as { version?: unknown };
   return typeof version === 'string' && version.length > 0 ? version : undefined;
+}
+
+export function shouldCheckDeployVersion(hostname: string) {
+  const normalizedHostname = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  return !['localhost', '127.0.0.1', '::1'].includes(normalizedHostname);
+}
+
+export function createDeployUpdateUrl(currentHref: string, serverVersion: string) {
+  const url = new URL(currentHref);
+  url.searchParams.set(DEPLOY_UPDATE_QUERY_PARAM, serverVersion);
+  return url.toString();
+}
+
+export function hasAttemptedDeployUpdate(currentHref: string, serverVersion: string) {
+  try {
+    return new URL(currentHref).searchParams.get(DEPLOY_UPDATE_QUERY_PARAM) === serverVersion;
+  }
+  catch {
+    return false;
+  }
+}
+
+export function clearCompletedDeployUpdateMarker(currentHref: string, currentVersion?: string) {
+  try {
+    const url = new URL(currentHref);
+    if (!currentVersion || url.searchParams.get(DEPLOY_UPDATE_QUERY_PARAM) !== currentVersion) {
+      return undefined;
+    }
+
+    url.searchParams.delete(DEPLOY_UPDATE_QUERY_PARAM);
+    return `${url.pathname}${url.search}${url.hash}`;
+  }
+  catch {
+    return undefined;
+  }
 }
 
 export function createDeployVersionChecker({


### PR DESCRIPTION
Superseded by direct revert on `netlify` (`a40a252c99110417bea4b291075a92d7ddc7e462`). The deploy update countdown changes from #34 were removed instead of patched further.