### PR TITLE
fix: harden deploy version reloads

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,20 +12,36 @@ import App from './App.vue';
 import router from './router';
 import { installGoogleAnalytics } from './plugins/google-analytics.plugin';
 import { i18nPlugin } from './plugins/i18n.plugin';
-import { createDeployVersionChecker } from './modules/app-version/deploy-version';
+import {
+  clearCompletedDeployUpdateMarker,
+  createDeployUpdateUrl,
+  createDeployVersionChecker,
+  hasAttemptedDeployUpdate,
+  shouldCheckDeployVersion,
+} from './modules/app-version/deploy-version';
+
+const deployVersion = import.meta.env.VITE_DEPLOY_VERSION;
+const completedUpdatePath = clearCompletedDeployUpdateMarker(window.location.href, deployVersion);
+if (completedUpdatePath) {
+  window.history.replaceState(window.history.state, '', completedUpdatePath);
+}
 
 const checkDeployVersion = createDeployVersionChecker({
-  currentVersion: import.meta.env.VITE_DEPLOY_VERSION,
+  currentVersion: deployVersion,
   versionManifestUrl: `${import.meta.env.BASE_URL}version.json`,
   origin: window.location.origin,
   isOnline: () => navigator.onLine,
   fetchVersion: (url, init) => fetch(url, init),
-  reload: () => window.location.reload(),
-});
+  onVersionMismatch: ({ serverVersion }) => {
+    // A normal reload can reuse a stale app shell in some browsers. Navigate to
+    // a URL marked with the target deploy so the document request is distinct.
+    // If the same old bundle boots again, do not auto-navigate a second time.
+    if (hasAttemptedDeployUpdate(window.location.href, serverVersion)) {
+      return;
+    }
 
-void checkDeployVersion();
-window.addEventListener('pageshow', () => {
-  void checkDeployVersion();
+    window.location.replace(createDeployUpdateUrl(window.location.href, serverVersion));
+  },
 });
 
 installGoogleAnalytics({ router });
@@ -40,3 +56,13 @@ app.use(naive);
 app.use(shadow);
 
 app.mount('#app');
+
+// Keep deploy polling out of local Playwright/Vite previews. In production,
+// start only after the app has mounted so version checking can never block the
+// initial Vue bootstrap. pageshow also covers a tab restored from bfcache.
+if (shouldCheckDeployVersion(window.location.hostname)) {
+  void checkDeployVersion();
+  window.addEventListener('pageshow', () => {
+    void checkDeployVersion();
+  });
+}

--- a/src/modules/app-version/deploy-version.spec.ts
+++ b/src/modules/app-version/deploy-version.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createDeployVersionChecker } from './deploy-version';
+import {
+  clearCompletedDeployUpdateMarker,
+  createDeployUpdateUrl,
+  createDeployVersionChecker,
+  hasAttemptedDeployUpdate,
+  shouldCheckDeployVersion,
+} from './deploy-version';
 
 function createResponse(version?: string, ok = true) {
   return {
@@ -20,7 +26,7 @@ function createChecker(options: {
   const online = options.online ?? true;
   const responseOk = options.responseOk ?? true;
 
-  const reload = vi.fn();
+  const onVersionMismatch = vi.fn();
   const fetchVersion = vi.fn().mockResolvedValue(createResponse(serverVersion, responseOk));
 
   const checkDeployVersion = createDeployVersionChecker({
@@ -29,75 +35,83 @@ function createChecker(options: {
     origin: 'https://tools.eplus.dev',
     isOnline: () => online,
     fetchVersion,
-    reload,
+    onVersionMismatch,
     now: () => 1234567890,
   });
 
   return {
     checkDeployVersion,
     fetchVersion,
-    reload,
+    onVersionMismatch,
   };
 }
 
 describe('deploy version checker', () => {
-  it('reloads a legacy visitor that has no embedded deploy version', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+  it('notifies a legacy visitor that has no embedded deploy version', async () => {
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: undefined,
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(reload).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledWith({
+      currentVersion: undefined,
+      serverVersion: 'deploy-v2',
+    });
   });
 
   it('does nothing for a new visitor already running the latest deploy', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: 'deploy-v2',
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(reload).not.toHaveBeenCalled();
+    expect(onVersionMismatch).not.toHaveBeenCalled();
   });
 
-  it('reloads a returning visitor when the server has a newer deploy', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+  it('notifies a returning visitor when the server has a newer deploy', async () => {
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: 'deploy-v2',
     });
 
     await checkDeployVersion();
 
-    expect(reload).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledWith({
+      currentVersion: 'deploy-v1',
+      serverVersion: 'deploy-v2',
+    });
   });
 
   it('ignores a manifest that does not contain a valid version', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: undefined,
     });
 
     await checkDeployVersion();
 
-    expect(reload).not.toHaveBeenCalled();
+    expect(onVersionMismatch).not.toHaveBeenCalled();
   });
 
   it('does not fetch the version manifest while offline', async () => {
-    const { checkDeployVersion, fetchVersion, reload } = createChecker({
+    const { checkDeployVersion, fetchVersion, onVersionMismatch } = createChecker({
       online: false,
     });
 
     await checkDeployVersion();
 
     expect(fetchVersion).not.toHaveBeenCalled();
-    expect(reload).not.toHaveBeenCalled();
+    expect(onVersionMismatch).not.toHaveBeenCalled();
   });
 
   it('ignores a failed version manifest response', async () => {
-    const { checkDeployVersion, reload } = createChecker({
+    const { checkDeployVersion, onVersionMismatch } = createChecker({
       currentVersion: 'deploy-v1',
       serverVersion: 'deploy-v2',
       responseOk: false,
@@ -105,7 +119,7 @@ describe('deploy version checker', () => {
 
     await checkDeployVersion();
 
-    expect(reload).not.toHaveBeenCalled();
+    expect(onVersionMismatch).not.toHaveBeenCalled();
   });
 
   it('uses a cache-busting version request', async () => {
@@ -125,13 +139,13 @@ describe('deploy version checker', () => {
     });
   });
 
-  it('deduplicates overlapping version checks and reloads once', async () => {
+  it('deduplicates overlapping version checks and mismatch notifications', async () => {
     let resolveResponse!: (value: ReturnType<typeof createResponse>) => void;
     const pendingResponse = new Promise<ReturnType<typeof createResponse>>((resolve) => {
       resolveResponse = resolve;
     });
     const fetchVersion = vi.fn().mockReturnValue(pendingResponse);
-    const reload = vi.fn();
+    const onVersionMismatch = vi.fn();
 
     const checkDeployVersion = createDeployVersionChecker({
       currentVersion: 'deploy-v1',
@@ -139,7 +153,7 @@ describe('deploy version checker', () => {
       origin: 'https://tools.eplus.dev',
       isOnline: () => true,
       fetchVersion,
-      reload,
+      onVersionMismatch,
       now: () => 1234567890,
     });
 
@@ -149,6 +163,59 @@ describe('deploy version checker', () => {
     await Promise.all([firstCheck, secondCheck]);
 
     expect(fetchVersion).toHaveBeenCalledOnce();
-    expect(reload).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledOnce();
+  });
+
+  it('does not notify again on pageshow after the mismatch was already announced', async () => {
+    const { checkDeployVersion, fetchVersion, onVersionMismatch } = createChecker({
+      currentVersion: 'deploy-v1',
+      serverVersion: 'deploy-v2',
+    });
+
+    await checkDeployVersion();
+    await checkDeployVersion();
+
+    expect(fetchVersion).toHaveBeenCalledOnce();
+    expect(onVersionMismatch).toHaveBeenCalledOnce();
+  });
+});
+
+describe('deploy update navigation guards', () => {
+  it('skips deploy polling on local preview hosts used by Playwright', () => {
+    expect(shouldCheckDeployVersion('localhost')).toBe(false);
+    expect(shouldCheckDeployVersion('127.0.0.1')).toBe(false);
+    expect(shouldCheckDeployVersion('[::1]')).toBe(false);
+    expect(shouldCheckDeployVersion('tools.eplus.dev')).toBe(true);
+  });
+
+  it('adds the target deploy and a fresh navigation nonce without losing user state in the URL', () => {
+    expect(createDeployUpdateUrl(
+      'https://tools.eplus.dev/vietqr-bank-generator?bank=970436#qr',
+      'deploy-v2',
+      1234567890,
+    )).toBe('https://tools.eplus.dev/vietqr-bank-generator?bank=970436&__eplus_update=deploy-v2&__eplus_reload=1234567890#qr');
+  });
+
+  it('detects when the browser already attempted the same deploy', () => {
+    expect(hasAttemptedDeployUpdate(
+      'https://tools.eplus.dev/?__eplus_update=deploy-v2&__eplus_reload=1',
+      'deploy-v2',
+    )).toBe(true);
+    expect(hasAttemptedDeployUpdate(
+      'https://tools.eplus.dev/?__eplus_update=deploy-v1&__eplus_reload=1',
+      'deploy-v2',
+    )).toBe(false);
+  });
+
+  it('cleans successful deploy markers while preserving the tool route, query and hash', () => {
+    expect(clearCompletedDeployUpdateMarker(
+      'https://tools.eplus.dev/vietqr-bank-generator?bank=970436&__eplus_update=deploy-v2&__eplus_reload=1234567890#qr',
+      'deploy-v2',
+    )).toBe('/vietqr-bank-generator?bank=970436#qr');
+
+    expect(clearCompletedDeployUpdateMarker(
+      'https://tools.eplus.dev/?__eplus_update=deploy-v1&__eplus_reload=1234567890',
+      'deploy-v2',
+    )).toBeUndefined();
   });
 });

--- a/src/modules/app-version/deploy-version.ts
+++ b/src/modules/app-version/deploy-version.ts
@@ -3,13 +3,21 @@ export interface VersionManifestResponse {
   json: () => Promise<unknown>
 }
 
+export interface DeployVersionMismatch {
+  currentVersion?: string
+  serverVersion: string
+}
+
+export const DEPLOY_UPDATE_QUERY_PARAM = '__eplus_update';
+export const DEPLOY_UPDATE_RELOAD_PARAM = '__eplus_reload';
+
 export interface DeployVersionCheckerOptions {
   currentVersion?: string
   versionManifestUrl: string
   origin: string
   isOnline: () => boolean
   fetchVersion: (url: URL, init: RequestInit) => Promise<VersionManifestResponse>
-  reload: () => void
+  onVersionMismatch: (versions: DeployVersionMismatch) => void
   now?: () => number
 }
 
@@ -22,19 +30,57 @@ function getManifestVersion(manifest: unknown) {
   return typeof version === 'string' && version.length > 0 ? version : undefined;
 }
 
+export function shouldCheckDeployVersion(hostname: string) {
+  const normalizedHostname = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  return !['localhost', '127.0.0.1', '::1'].includes(normalizedHostname);
+}
+
+export function createDeployUpdateUrl(currentHref: string, serverVersion: string, reloadNonce = Date.now()) {
+  const url = new URL(currentHref);
+  url.searchParams.set(DEPLOY_UPDATE_QUERY_PARAM, serverVersion);
+  url.searchParams.set(DEPLOY_UPDATE_RELOAD_PARAM, reloadNonce.toString());
+  return url.toString();
+}
+
+export function hasAttemptedDeployUpdate(currentHref: string, serverVersion: string) {
+  try {
+    return new URL(currentHref).searchParams.get(DEPLOY_UPDATE_QUERY_PARAM) === serverVersion;
+  }
+  catch {
+    return false;
+  }
+}
+
+export function clearCompletedDeployUpdateMarker(currentHref: string, currentVersion?: string) {
+  try {
+    const url = new URL(currentHref);
+    if (!currentVersion || url.searchParams.get(DEPLOY_UPDATE_QUERY_PARAM) !== currentVersion) {
+      return undefined;
+    }
+
+    url.searchParams.delete(DEPLOY_UPDATE_QUERY_PARAM);
+    url.searchParams.delete(DEPLOY_UPDATE_RELOAD_PARAM);
+    return `${url.pathname}${url.search}${url.hash}`;
+  }
+  catch {
+    return undefined;
+  }
+}
+
 export function createDeployVersionChecker({
   currentVersion,
   versionManifestUrl,
   origin,
   isOnline,
   fetchVersion,
-  reload,
+  onVersionMismatch,
   now = Date.now,
 }: DeployVersionCheckerOptions) {
   let versionCheckRunning = false;
+  let versionMismatchNotified = false;
 
   return async function checkDeployVersion() {
-    if (versionCheckRunning || !isOnline()) {
+    if (versionCheckRunning || versionMismatchNotified || !isOnline()) {
       return;
     }
 
@@ -61,10 +107,8 @@ export function createDeployVersionChecker({
         return;
       }
 
-      // HTML is served with no-store and application assets are content-hashed.
-      // Reloading directly is therefore enough to move the browser to the new
-      // deploy without depending on Service Worker lifecycle timing.
-      reload();
+      versionMismatchNotified = true;
+      onVersionMismatch({ currentVersion, serverVersion });
     }
     catch {
       // Keep the current app usable if the version endpoint is temporarily unavailable.


### PR DESCRIPTION
## Scope
This is intentionally limited to deploy-version reload behavior after the `vue-i18n` regression was fixed. It does **not** change Vite auto-imports, UI, countdown dialogs, Service Worker generation, or GitHub Actions.

## What changed
- check `version.json` only after Vue has mounted
- skip deploy polling on localhost/127.0.0.1/::1 previews
- replace plain `window.location.reload()` with one fresh navigation carrying the target deploy + nonce
- preserve the current tool route, existing query parameters, and hash
- prevent a second automatic navigation if the browser still boots the same stale bundle for the same deploy
- clean the temporary deploy markers once the expected bundle successfully boots
- deduplicate repeated/pageshow mismatch notifications
- add focused unit coverage for version mismatch handling and reload-loop guards

## Why
`index.html` and `version.json` are already served `no-store`, Vite assets are content-hashed/immutable, and new visitors do not register the generated Workbox worker. The remaining edge case is a browser reusing a stale app shell even after a normal reload. This PR makes that update path one-shot per deploy instead of allowing a possible reload loop.

## Safety check
Compared with the current `netlify` head, exactly 3 files are changed:
- `src/main.ts`
- `src/modules/app-version/deploy-version.ts`
- `src/modules/app-version/deploy-version.spec.ts`

No unrelated config change is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment version checks to prevent repeated redirects and notifications.
  * Users are now directed to a deployment-specific update URL when a newer version is detected.
  * Version checks run only in production-like environments and handle restored browser tabs more reliably.
  * Local previews no longer perform deployment polling.
* **Tests**
  * Expanded coverage for version mismatch notifications, duplicate prevention, URL handling, and completed-update cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->