### PR TITLE
ci: scope E2E runs to relevant changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,40 +7,92 @@ on:
       - main
       - netlify
 
+# Only the newest revision of a PR/branch needs validation. Cancel superseded
+# runs so they do not keep consuming a GitHub-hosted runner.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: corepack enable
+        with:
+          fetch-depth: 0
+
+      - name: Detect CI-impacting changes
+        id: changes
+        shell: bash
+        run: |
+          # Keep full validation on protected deployment branches. The change
+          # filter only reduces work for pull requests.
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run_ci=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" > changed.txt
+
+          echo "Changed files:"
+          cat changed.txt
+
+          # App source, tests, build scripts, dependencies, and tooling configs
+          # can affect lint/typecheck/unit/build results. Docs, GitHub workflow
+          # files and repository metadata do not require the expensive app CI.
+          if grep -Eq '^(src/|public/|scripts/|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|index\.html$|\.nvmrc$|env\.d\.ts$|vite\.config\.[^/]+$|vitest\.config\.[^/]+$|tsconfig(\.[^/]+)?\.json$|eslint\.config\.[^/]+$|stylelint\.config\.[^/]+$|prettier\.config\.[^/]+$|\.eslintrc([^/]*)$|\.stylelintrc([^/]*)$|\.prettierrc([^/]*)$)' changed.txt; then
+            echo "run_ci=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_ci=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip app CI for unrelated changes
+        if: steps.changes.outputs.run_ci != 'true'
+        run: echo "No app/tooling files changed; skipping dependency install, lint, tests, typecheck and build."
+
+      - name: Enable Corepack
+        if: steps.changes.outputs.run_ci == 'true'
+        run: corepack enable
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: steps.changes.outputs.run_ci == 'true'
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.changes.outputs.run_ci == 'true'
         run: pnpm i
 
       - name: Run linters
+        if: steps.changes.outputs.run_ci == 'true'
         run: pnpm lint
 
       - name: Test ePlus related-tool recommendations
+        if: steps.changes.outputs.run_ci == 'true'
         run: pnpm exec vitest run --environment jsdom src/tools/tool-recommendations.test.ts
 
       - name: Test ePlus developer workflows
+        if: steps.changes.outputs.run_ci == 'true'
         run: pnpm exec vitest run --environment jsdom src/tools/developer-workflows.test.ts
 
       - name: Test ePlus developer workspace
+        if: steps.changes.outputs.run_ci == 'true'
         run: pnpm exec vitest run --environment jsdom src/modules/developer-workspace/workspace.model.test.ts src/modules/developer-workspace/workspace-suggestions.test.ts
 
       - name: Run unit test
+        if: steps.changes.outputs.run_ci == 'true'
         run: pnpm test
 
       - name: Type check
+        if: steps.changes.outputs.run_ci == 'true'
         run: pnpm typecheck
 
       - name: Build the app
+        if: steps.changes.outputs.run_ci == 'true'
         env:
           DEPLOY_ID: github-${{ github.run_id }}-${{ github.run_attempt }}
           COMMIT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -48,6 +100,7 @@ jobs:
         run: pnpm build
 
       - name: Review production build artifacts
+        if: steps.changes.outputs.run_ci == 'true'
         env:
           DEPLOY_ID: github-${{ github.run_id }}-${{ github.run_attempt }}
           COMMIT_REF: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,23 +26,29 @@ jobs:
         id: changes
         shell: bash
         run: |
-          # Keep full validation on protected deployment branches. The change
-          # filter only reduces work for pull requests.
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "run_ci=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
           fi
 
-          git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" > changed.txt
+          # A zero SHA can occur on the first push of a ref. Fall back to the
+          # files contained in HEAD so an app/tooling change is never missed.
+          if [[ -z "$BASE" || "$BASE" =~ ^0+$ ]]; then
+            git diff-tree --no-commit-id --name-only -r "$HEAD" > changed.txt
+          else
+            git diff --name-only "$BASE" "$HEAD" > changed.txt
+          fi
 
           echo "Changed files:"
           cat changed.txt
 
           # App source, tests, build scripts, dependencies, and tooling configs
           # can affect lint/typecheck/unit/build results. Docs, GitHub workflow
-          # files and repository metadata do not require the expensive app CI.
+          # files and repository metadata do not require expensive app CI,
+          # including after they are merged into main/netlify.
           if grep -Eq '^(src/|public/|scripts/|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|index\.html$|\.nvmrc$|env\.d\.ts$|vite\.config\.[^/]+$|vitest\.config\.[^/]+$|tsconfig(\.[^/]+)?\.json$|eslint\.config\.[^/]+$|stylelint\.config\.[^/]+$|prettier\.config\.[^/]+$|\.eslintrc([^/]*)$|\.stylelintrc([^/]*)$|\.prettierrc([^/]*)$)' changed.txt; then
             echo "run_ci=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,19 +1,107 @@
 name: E2E tests
+
 on:
   pull_request:
   push:
     branches:
       - main
       - netlify
+
+# A new commit makes an older run obsolete. Free the runner immediately instead
+# of spending minutes validating code that is no longer the PR head.
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Pull requests use the cheapest useful level of E2E coverage:
+  # - docs/workflow/metadata-only changes: no Node/Playwright setup at all
+  # - runtime-impacting changes: Chromium only
+  # Full cross-browser coverage still runs after changes land on main/netlify.
   test:
+    if: github.event_name == 'pull_request'
     timeout-minutes: 12
-    # Playwright 1.32 predates Ubuntu 24.04 support. Pin Jammy until
-    # Playwright is upgraded to a release that officially supports Noble.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect E2E-impacting changes
+        id: changes
+        shell: bash
+        run: |
+          git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" > changed.txt
+
+          echo "Changed files:"
+          cat changed.txt
+
+          # Only files that can change the built/runtime application require
+          # browser E2E on a pull request. CI/docs/repository metadata are
+          # intentionally excluded because they cannot change app behaviour.
+          if grep -Eq '^(src/|public/|package\.json$|pnpm-lock\.yaml$|index\.html$|vite\.config\.[^/]+$|playwright\.config\.[^/]+$|tsconfig(\.[^/]+)?\.json$|\.nvmrc$)' changed.txt; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip E2E for unrelated changes
+        if: steps.changes.outputs.run_e2e != 'true'
+        run: echo "No runtime-impacting files changed; skipping Playwright setup and tests."
+
+      - name: Enable Corepack
+        if: steps.changes.outputs.run_e2e == 'true'
+        run: corepack enable
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: steps.changes.outputs.run_e2e == 'true'
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Get Playwright version
+        if: steps.changes.outputs.run_e2e == 'true'
+        id: playwright-version
+        run: |
+          PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")
+          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        if: steps.changes.outputs.run_e2e == 'true'
+        run: pnpm install
+
+      - name: Build app
+        if: steps.changes.outputs.run_e2e == 'true'
+        run: pnpm build
+
+      - name: Restore Chromium from cache
+        if: steps.changes.outputs.run_e2e == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}-chromium-${{ hashFiles('**/playwright.config.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}-chromium-
+            ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}-
+            ${{ runner.os }}-playwright-
+
+      - name: Install Chromium
+        if: steps.changes.outputs.run_e2e == 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Chromium E2E tests
+        if: steps.changes.outputs.run_e2e == 'true'
+        run: pnpm run test:e2e --project=chromium
+
+  full-test:
+    if: github.event_name == 'push'
+    timeout-minutes: 12
     runs-on: ubuntu-22.04
     strategy:
-      # Keep only one E2E shard on a runner at a time so this repository does
-      # not occupy all available GitHub-hosted runners while other repos run.
+      # Keep only one shard on a runner at a time so this repository does not
+      # occupy all available GitHub-hosted runners while other repos run.
       max-parallel: 1
       matrix:
         shard: [1/3, 2/3, 3/3]

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,21 +7,20 @@ on:
       - main
       - netlify
 
-# A new commit makes an older run obsolete. Free the runner immediately instead
-# of spending minutes validating code that is no longer the PR head.
+# A new commit makes an older run obsolete. Free runners immediately instead
+# of validating code that is no longer the latest PR/branch revision.
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Pull requests use the cheapest useful level of E2E coverage:
-  # - docs/workflow/metadata-only changes: no Node/Playwright setup at all
-  # - runtime-impacting changes: Chromium only
-  # Full cross-browser coverage still runs after changes land on main/netlify.
-  test:
-    if: github.event_name == 'pull_request'
-    timeout-minutes: 12
-    runs-on: ubuntu-22.04
+  # Do one cheap diff check before allocating browser-test runners. This runs
+  # for both PRs and protected-branch pushes so docs/workflow/metadata-only
+  # changes never install Node, browsers or execute Playwright.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run_e2e: ${{ steps.changes.outputs.run_e2e }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -31,53 +30,65 @@ jobs:
         id: changes
         shell: bash
         run: |
-          git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" > changed.txt
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+
+          # A zero SHA can occur on the first push of a ref. Fall back to the
+          # files contained in HEAD so a real app change is never missed.
+          if [[ -z "$BASE" || "$BASE" =~ ^0+$ ]]; then
+            git diff-tree --no-commit-id --name-only -r "$HEAD" > changed.txt
+          else
+            git diff --name-only "$BASE" "$HEAD" > changed.txt
+          fi
 
           echo "Changed files:"
           cat changed.txt
 
-          # Only files that can change the built/runtime application require
-          # browser E2E on a pull request. CI/docs/repository metadata are
-          # intentionally excluded because they cannot change app behaviour.
-          if grep -Eq '^(src/|public/|package\.json$|pnpm-lock\.yaml$|index\.html$|vite\.config\.[^/]+$|playwright\.config\.[^/]+$|tsconfig(\.[^/]+)?\.json$|\.nvmrc$)' changed.txt; then
+          # Only files that can affect the built/runtime app or browser tests
+          # need E2E. Docs, GitHub workflows and repository metadata are
+          # intentionally excluded.
+          if grep -Eq '^(src/|public/|scripts/|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|index\.html$|\.nvmrc$|env\.d\.ts$|vite\.config\.[^/]+$|playwright\.config\.[^/]+$|tsconfig(\.[^/]+)?\.json$)' changed.txt; then
             echo "run_e2e=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+            echo "No runtime-impacting files changed; browser E2E will be skipped."
           fi
 
-      - name: Skip E2E for unrelated changes
-        if: steps.changes.outputs.run_e2e != 'true'
-        run: echo "No runtime-impacting files changed; skipping Playwright setup and tests."
+  # Pull requests use the cheapest useful browser coverage: Chromium only.
+  test:
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.run_e2e == 'true'
+    timeout-minutes: 12
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Enable Corepack
-        if: steps.changes.outputs.run_e2e == 'true'
         run: corepack enable
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        if: steps.changes.outputs.run_e2e == 'true'
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - name: Get Playwright version
-        if: steps.changes.outputs.run_e2e == 'true'
         id: playwright-version
         run: |
           PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")
           echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
-        if: steps.changes.outputs.run_e2e == 'true'
         run: pnpm install
 
       - name: Build app
-        if: steps.changes.outputs.run_e2e == 'true'
         run: pnpm build
 
       - name: Restore Chromium from cache
-        if: steps.changes.outputs.run_e2e == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
@@ -88,27 +99,26 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Chromium
-        if: steps.changes.outputs.run_e2e == 'true'
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Chromium E2E tests
-        if: steps.changes.outputs.run_e2e == 'true'
         run: pnpm run test:e2e --project=chromium
 
+  # After a runtime-impacting change lands on main/netlify, preserve the old
+  # full coverage and let all three shards run in parallel again.
   full-test:
-    if: github.event_name == 'push'
+    needs: changes
+    if: github.event_name == 'push' && needs.changes.outputs.run_e2e == 'true'
     timeout-minutes: 12
     runs-on: ubuntu-22.04
     strategy:
-      # Keep only one shard on a runner at a time so this repository does not
-      # occupy all available GitHub-hosted runners while other repos run.
-      max-parallel: 1
       matrix:
         shard: [1/3, 2/3, 3/3]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - run: corepack enable
+      - name: Enable Corepack
+        run: corepack enable
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Summary

Reduce GitHub Actions runner usage without removing meaningful validation.

### Pull requests
- `ci` and `E2E tests` classify changed files first.
- Docs/workflow/repository-metadata-only changes skip expensive app validation.
- App/tooling changes run the normal `ci` suite.
- Runtime-impacting PRs run Chromium E2E only.

### main / netlify
- Changed files are checked again after merge/push.
- If the push does not affect the app/runtime/tooling, app CI and browser E2E are skipped.
- If runtime-impacting files changed, full Playwright coverage runs across Chromium, Firefox, and WebKit using the original 3 shards.
- The 3 protected-branch E2E shards are allowed to run in parallel again; `max-parallel: 1` has been removed.

### Runner cleanup
- `concurrency.cancel-in-progress` cancels superseded runs when a newer commit is pushed to the same PR/branch.
- Timeout remains 12 minutes.

### Current PR verification
This PR only changes GitHub workflow files, so it should take the cheap change-detection path and skip Node/dependency/test/build/Playwright work.